### PR TITLE
Correct error dialog on second run of saving identity.

### DIFF
--- a/app/src/main/java/org/ea/sqrl/activites/identity/ExportOptionsActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/identity/ExportOptionsActivity.java
@@ -42,10 +42,11 @@ public class ExportOptionsActivity extends BaseActivity {
         findViewById(R.id.btnSaveIdentity).setOnClickListener(v -> {
             String uriString = "content://org.ea.sqrl.fileprovider/sqrltmp/";
             File directory = new File(getCacheDir(), "sqrltmp");
+            if(!directory.exists()) directory.mkdir();
 
             System.out.println(directory.getAbsolutePath());
 
-            if(!directory.mkdir()) {
+            if(!directory.exists()) {
                 showErrorMessage(R.string.main_activity_could_not_create_dir);
                 return;
             }


### PR DESCRIPTION
Issue:
#209  

Description:
Added a check to see if the directory exists.  Only throw the error if, after we try to created it, the directory still doesn't exist.

Changes:
ExportOptionsActivity.java
