### PR TITLE
WIP: Add password paste in 2 places

### DIFF
--- a/app/src/main/java/org/ea/sqrl/activites/SettingsActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/SettingsActivity.java
@@ -1,10 +1,13 @@
 package org.ea.sqrl.activites;
 
+import android.content.ClipData;
+import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Handler;
 import android.support.constraint.ConstraintLayout;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -14,6 +17,7 @@ import android.widget.CheckBox;
 import android.widget.EditText;
 import android.widget.PopupWindow;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import org.ea.sqrl.R;
 import org.ea.sqrl.activites.base.BaseActivity;
@@ -85,6 +89,31 @@ public class SettingsActivity extends BaseActivity {
         savePopupWindow.setFocusable(true);
 
         final EditText txtPassword = popupView.findViewById(R.id.txtPassword);
+        final Context activityContext = this;
+
+        txtPassword.setOnLongClickListener(view -> {
+            StringBuilder longClickResultMessage = new StringBuilder("Password paste failed.");
+            ClipboardManager cm = (ClipboardManager)getApplicationContext().getSystemService(Context.CLIPBOARD_SERVICE);
+            Log.v(TAG, "long click detected with " + cm.getPrimaryClip().getItemCount() + " items.");
+            if (cm.getPrimaryClip().getItemCount() > 0) {
+                ClipData.Item clipItem  = cm.getPrimaryClip().getItemAt(0);
+                CharSequence clipItemText = clipItem.getText();
+                if (clipItemText.length() < 3) {
+                    longClickResultMessage.append(" The clipboard item was too short to be a password.");
+                } else {
+                    txtPassword.setText(clipItem.getText());
+                    Log.v(TAG, "Successfully pasted password.");
+                    Toast.makeText(activityContext, "Pasted clipboard contents", Toast.LENGTH_SHORT).show();
+                    return true;
+                }
+            } else {
+                longClickResultMessage.append(" The clipboard was empty.");
+            }
+            Log.v(TAG, longClickResultMessage.toString());
+            return false;
+        });
+
+
         final TextView progressText = popupView.findViewById(R.id.lblProgressText);
 
         SQRLStorage storage = SQRLStorage.getInstance();

--- a/app/src/main/java/org/ea/sqrl/activites/base/LoginBaseActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/base/LoginBaseActivity.java
@@ -1,6 +1,8 @@
 package org.ea.sqrl.activites.base;
 
 import android.annotation.SuppressLint;
+import android.content.ClipData;
+import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -22,6 +24,7 @@ import android.widget.PopupWindow;
 import android.widget.ProgressBar;
 import android.widget.Spinner;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import org.ea.sqrl.R;
 import org.ea.sqrl.activites.account.AccountOptionsActivity;
@@ -230,6 +233,28 @@ public class LoginBaseActivity extends BaseActivity implements AdapterView.OnIte
             @Override
             public void afterTextChanged(Editable s) {
             }
+        });
+
+        txtLoginPassword.setOnLongClickListener(view -> {
+            StringBuilder longClickResultMessage = new StringBuilder("Password paste failed.");
+            ClipboardManager cm = (ClipboardManager)getApplicationContext().getSystemService(Context.CLIPBOARD_SERVICE);
+            Log.v(TAG, "long click detected with " + cm.getPrimaryClip().getItemCount() + " items.");
+            if (cm.getPrimaryClip().getItemCount() > 0) {
+                ClipData.Item clipItem  = cm.getPrimaryClip().getItemAt(0);
+                CharSequence clipItemText = clipItem.getText();
+                if (clipItemText.length() < 3) {
+                    longClickResultMessage.append(" The clipboard item was too short to be a password.");
+                } else {
+                    txtLoginPassword.setText(clipItem.getText());
+                    Log.v(TAG, "Successfully pasted password.");
+                    Toast.makeText(quickPassContext, "Pasted clipboard contents", Toast.LENGTH_SHORT).show();
+                    return true;
+                }
+            } else {
+                longClickResultMessage.append(" The clipboard was empty.");
+            }
+            Log.v(TAG, longClickResultMessage.toString());
+            return false;
         });
 
         popupView.findViewById(R.id.btnCloseLogin).setOnClickListener(v -> hideLoginPopup());


### PR DESCRIPTION
Issue #244

Description:
Listener on *two* password fields that pastes clipboard contents

Changes:
Added long click listeners that pastes the contents of the clipboard if the user does a long click on the password fields. A short toast confirms the paste if successful. If the clipboard is empty or contains something short, it doesn't do anything (except some logging).

Notes:
The toast text probably should be put into strings.xml, but I didn't know how to get it into all languages (figured there might be automation to manage that).

This might not be the "perfect" way to implement this since instead of pasting on a long click, it could interact with the user before pasting.

It's possible that they've already got contents in the field. If so, it's replaced with the clipboard contents.

The clipboard is not cleared after the paste occurs because ClipboardManager.clearPrimaryClip() throws a NoSuchMethodError, and I didn't see an alternative.