### PR TITLE
Prevent next action from covering error

### DIFF
--- a/app/src/main/java/org/ea/sqrl/activites/base/BaseActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/base/BaseActivity.java
@@ -269,11 +269,19 @@ public class BaseActivity extends AppCompatActivity {
         showErrorMessageInternal(getString(id));
     }
 
+    public void showErrorMessage(int id, Runnable nextAction) {
+        showErrorMessageInternal(getString(id), nextAction);
+    }
+
     public void showErrorMessage(String message) {
         showErrorMessageInternal(message);
     }
 
     public void showErrorMessageInternal(String message) {
+        showErrorMessageInternal(message, null);
+    }
+
+    public void showErrorMessageInternal(String message, Runnable nextAction) {
 
         AlertDialog.Builder builder;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
@@ -282,6 +290,14 @@ public class BaseActivity extends AppCompatActivity {
                 errorPopupWindow.getContentView() != null &&
                 !isFinishing()
             ) {
+                if (nextAction != null) {
+                    errorPopupWindow.setOnDismissListener(new PopupWindow.OnDismissListener() {
+                        @Override
+                        public void onDismiss() {
+                            nextAction.run();
+                        }
+                    });
+                }
                 txtErrorMessage.setText(message);
                 handler.post(() ->
                     errorPopupWindow.showAtLocation(errorPopupWindow.getContentView(), Gravity.CENTER, 0, 0)
@@ -298,6 +314,9 @@ public class BaseActivity extends AppCompatActivity {
                     .setMessage(message)
                     .setPositiveButton(android.R.string.ok, (dialog, which) -> {
                         dialog.dismiss();
+                        if (nextAction != null) {
+                            nextAction.run();
+                        }
                     })
                     .setIcon(android.R.drawable.ic_dialog_alert)
                     .show()

--- a/app/src/main/java/org/ea/sqrl/activites/base/LoginBaseActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/base/LoginBaseActivity.java
@@ -172,12 +172,17 @@ public class LoginBaseActivity extends BaseActivity implements AdapterView.OnIte
                     new Thread(() -> {
                         boolean decryptionOk = storage.decryptIdentityKey(password.toString(), entropyHarvester, true);
                         if(!decryptionOk) {
-                            showErrorMessage(R.string.decrypt_identity_fail);
+                            final Runnable nextAction = new Runnable() {
+                                @Override
+                                public void run() {
+                                    showLoginPopup();
+                                }
+                            };
+                            showErrorMessage(R.string.decrypt_identity_fail, nextAction);
                             handler.post(() -> {
                                 txtLoginPassword.setHint(R.string.login_identity_password);
                                 txtLoginPassword.setText("");
                                 hideProgressPopup();
-                                showLoginPopup();
                             });
                             storage.clear();
                             storage.clearQuickPass(quickPassContext);


### PR DESCRIPTION
Issue #263
Description:
New method signatures that include a runnable for BaseActivity 

Changes:
Pass a runnable into the `showErrorMessage` method so that the next action is shown *after* the user sees the dialog.
