### PR TITLE
Added refreshStorageFromDb and used it before printing identity

### DIFF
--- a/app/src/main/java/org/ea/sqrl/processors/SQRLStorage.java
+++ b/app/src/main/java/org/ea/sqrl/processors/SQRLStorage.java
@@ -1,9 +1,7 @@
 package org.ea.sqrl.processors;
 
-import android.app.Activity;
 import android.app.NotificationManager;
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.os.Build;
 import android.os.Handler;
 import android.security.keystore.KeyGenParameterSpec;
@@ -14,7 +12,6 @@ import android.widget.TextView;
 
 import org.ea.sqrl.R;
 import org.ea.sqrl.activites.base.BaseActivity;
-import org.ea.sqrl.database.IdentityDBHelper;
 import org.ea.sqrl.jni.Grc_aesgcm;
 import org.ea.sqrl.utils.EncryptionUtils;
 import org.libsodium.jni.NaCl;
@@ -141,18 +138,6 @@ public class SQRLStorage {
         }
         byte[] oldData = this.createSaveData();
         return !Arrays.equals(identityData, oldData);
-    }
-
-    public void refreshStorageFromDb(Activity activity) throws Exception {
-        SharedPreferences sharedPref = activity.getApplication().getSharedPreferences(
-                "org.ea.sqrl.preferences",
-                Context.MODE_PRIVATE
-        );
-        long currentId = sharedPref.getLong("current_id", 0);
-        IdentityDBHelper aDbHelper = new IdentityDBHelper(activity);
-        byte[] identityData = aDbHelper.getIdentityData(currentId);
-        SQRLStorage sqrlStorage = SQRLStorage.getInstance();
-        sqrlStorage.read(identityData);
     }
 
     public void read(byte[] input) throws Exception {

--- a/app/src/main/java/org/ea/sqrl/processors/SQRLStorage.java
+++ b/app/src/main/java/org/ea/sqrl/processors/SQRLStorage.java
@@ -1,7 +1,9 @@
 package org.ea.sqrl.processors;
 
+import android.app.Activity;
 import android.app.NotificationManager;
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.os.Build;
 import android.os.Handler;
 import android.security.keystore.KeyGenParameterSpec;
@@ -12,6 +14,7 @@ import android.widget.TextView;
 
 import org.ea.sqrl.R;
 import org.ea.sqrl.activites.base.BaseActivity;
+import org.ea.sqrl.database.IdentityDBHelper;
 import org.ea.sqrl.jni.Grc_aesgcm;
 import org.ea.sqrl.utils.EncryptionUtils;
 import org.libsodium.jni.NaCl;
@@ -138,6 +141,18 @@ public class SQRLStorage {
         }
         byte[] oldData = this.createSaveData();
         return !Arrays.equals(identityData, oldData);
+    }
+
+    public void refreshStorageFromDb(Activity activity) throws Exception {
+        SharedPreferences sharedPref = activity.getApplication().getSharedPreferences(
+                "org.ea.sqrl.preferences",
+                Context.MODE_PRIVATE
+        );
+        long currentId = sharedPref.getLong("current_id", 0);
+        IdentityDBHelper aDbHelper = new IdentityDBHelper(activity);
+        byte[] identityData = aDbHelper.getIdentityData(currentId);
+        SQRLStorage sqrlStorage = SQRLStorage.getInstance();
+        sqrlStorage.read(identityData);
     }
 
     public void read(byte[] input) throws Exception {

--- a/app/src/main/java/org/ea/sqrl/services/IdentityPrintDocumentAdapter.java
+++ b/app/src/main/java/org/ea/sqrl/services/IdentityPrintDocumentAdapter.java
@@ -203,6 +203,7 @@ public class IdentityPrintDocumentAdapter extends PrintDocumentAdapter {
         int i = 0;
         try {
             paint.setTypeface(Typeface.MONOSPACE);
+            storage.refreshStorageFromDb(activity);
             for (String s : storage.getVerifyingRecoveryBlock().split("\n")) {
                 drawCenteredText(canvas, paint, s, lastBlockY + bodyText + (i * bodyText), bodyText);
                 i++;

--- a/app/src/main/java/org/ea/sqrl/services/IdentityPrintDocumentAdapter.java
+++ b/app/src/main/java/org/ea/sqrl/services/IdentityPrintDocumentAdapter.java
@@ -32,6 +32,7 @@ import com.journeyapps.barcodescanner.BarcodeEncoder;
 
 import org.ea.sqrl.R;
 import org.ea.sqrl.processors.SQRLStorage;
+import org.ea.sqrl.utils.Utils;
 
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -203,7 +204,7 @@ public class IdentityPrintDocumentAdapter extends PrintDocumentAdapter {
         int i = 0;
         try {
             paint.setTypeface(Typeface.MONOSPACE);
-            storage.refreshStorageFromDb(activity);
+            Utils.refreshStorageFromDb(activity);
             for (String s : storage.getVerifyingRecoveryBlock().split("\n")) {
                 drawCenteredText(canvas, paint, s, lastBlockY + bodyText + (i * bodyText), bodyText);
                 i++;

--- a/app/src/main/java/org/ea/sqrl/utils/Utils.java
+++ b/app/src/main/java/org/ea/sqrl/utils/Utils.java
@@ -1,5 +1,6 @@
 package org.ea.sqrl.utils;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -10,6 +11,9 @@ import android.util.DisplayMetrics;
 import android.util.Log;
 
 import com.google.zxing.FormatException;
+
+import org.ea.sqrl.database.IdentityDBHelper;
+import org.ea.sqrl.processors.SQRLStorage;
 
 import java.util.Locale;
 
@@ -60,5 +64,17 @@ public class Utils {
             conf.setLocale(new Locale(lang));
             res.updateConfiguration(conf, res.getDisplayMetrics());
         }
+    }
+
+    public static void refreshStorageFromDb(Activity activity) throws Exception {
+        SharedPreferences sharedPref = activity.getApplication().getSharedPreferences(
+                "org.ea.sqrl.preferences",
+                Context.MODE_PRIVATE
+        );
+        long currentId = sharedPref.getLong("current_id", 0);
+        IdentityDBHelper aDbHelper = new IdentityDBHelper(activity);
+        byte[] identityData = aDbHelper.getIdentityData(currentId);
+        SQRLStorage sqrlStorage = SQRLStorage.getInstance();
+        sqrlStorage.read(identityData);
     }
 }


### PR DESCRIPTION
Issue #265

Description:
Earlier, I had observed that if the fields of the storage object were refreshed from the database before printing the identity PDF, then the verify block was of proper length, whereas if this read was not done, the error of the issue (longer than expected verify block) was printed.

I examined both `IdentityPrintDocumentAdapter` and also `ShowIdentityActivity`.  The latter activity appeared to already be refreshing the storage object from the database before use, so no changes appear to be required for that activity.  Those two places are where the problem `getVerifyingRecoveryBlock()` is being used in a new install / new identity situation that the issue describes.

Changes:
Added a method that refreshes the content of the storage object from the database and uses that method before printing the PDF.
