### PR TITLE
doLogin code cleanup

### DIFF
--- a/app/src/main/java/org/ea/sqrl/activites/account/AlternativeLoginActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/account/AlternativeLoginActivity.java
@@ -42,44 +42,7 @@ public class AlternativeLoginActivity extends LoginBaseActivity {
             long currentId = sharedPref.getLong(CURRENT_ID, 0);
 
             if(currentId != 0) {
-                hideLoginPopup();
-                showProgressPopup();
-                closeKeyboard();
-
-                new Thread(() -> {
-                    boolean decryptionOk = storage.decryptIdentityKey(txtLoginPassword.getText().toString(), entropyHarvester, false);
-                    if(!decryptionOk) {
-                        showErrorMessage(R.string.decrypt_identity_fail);
-                        handler.post(() -> {
-                            txtLoginPassword.setText("");
-                            hideProgressPopup();
-                        });
-                        storage.clear();
-                        return;
-                    }
-                    showClearNotification();
-
-                    handler.post(() -> txtLoginPassword.setText(""));
-
-                    communicationFlowHandler.addAction(CommunicationFlowHandler.Action.QUERY_WITHOUT_SUK_QRCODE);
-                    communicationFlowHandler.addAction(CommunicationFlowHandler.Action.LOGIN);
-
-                    communicationFlowHandler.setDoneAction(() -> {
-                        storage.clear();
-                        handler.post(() -> {
-                            hideProgressPopup();
-                            closeActivity();
-                        });
-                        AlternativeLoginActivity.this.finish();
-                    });
-
-                    communicationFlowHandler.setErrorAction(() -> {
-                        storage.clear();
-                        handler.post(() -> hideProgressPopup());
-                    });
-
-                    communicationFlowHandler.handleNextAction();
-                }).start();
+                doLogin(storage, txtLoginPassword, false, false, AlternativeLoginActivity.this, this);
             }
         });
     }

--- a/app/src/main/java/org/ea/sqrl/activites/base/LoginBaseActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/base/LoginBaseActivity.java
@@ -213,18 +213,26 @@ public class LoginBaseActivity extends BaseActivity implements AdapterView.OnIte
         new Thread(() -> {
             boolean decryptionOk = storage.decryptIdentityKey(txtLoginPassword.getText().toString(), entropyHarvester, usedQuickpass);
             if(!decryptionOk) {
+                if (!usedCps) {
+                    final Runnable nextAction = new Runnable() {
+                        @Override
+                        public void run() {
+                            showLoginPopup();
+                        }
+                    };
+                }
                 showErrorMessage(R.string.decrypt_identity_fail);
                 handler.post(() -> {
-                    txtLoginPassword.setHint(R.string.login_identity_password); // Should be in both?
+                    txtLoginPassword.setHint(R.string.login_identity_password);
                     txtLoginPassword.setText("");
                     hideProgressPopup();
-                    if (!usedCps) showLoginPopup();
+                    showLoginPopup();
                 });
                 storage.clear();
                 storage.clearQuickPass(context);
                 return;
             }
-            if(!usedQuickpass) showClearNotification(); // RUN ONLY IF FULL PASSWORD TYPED
+            if(!usedQuickpass) showClearNotification(); 
 
             handler.post(() -> txtLoginPassword.setText(""));
 

--- a/app/src/main/res/layout-land/activity_url_login.xml
+++ b/app/src/main/res/layout-land/activity_url_login.xml
@@ -117,7 +117,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="@string/login_identity_password"
-            android:inputType="textPassword"/>
+            android:inputType="textPassword"
+            android:imeOptions="actionDone"/>
     </android.support.design.widget.TextInputLayout>
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout-land/fragment_login.xml
+++ b/app/src/main/res/layout-land/fragment_login.xml
@@ -130,7 +130,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:hint="@string/login_identity_password"
-                android:inputType="textPassword"/>
+                android:inputType="textPassword"
+                android:imeOptions="actionDone"/>
         </android.support.design.widget.TextInputLayout>
 
     </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/activity_url_login.xml
+++ b/app/src/main/res/layout/activity_url_login.xml
@@ -121,7 +121,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="@string/login_identity_password"
-            android:inputType="textPassword"/>
+            android:inputType="textPassword"
+            android:imeOptions="actionDone"/>
     </android.support.design.widget.TextInputLayout>
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_login.xml
+++ b/app/src/main/res/layout/fragment_login.xml
@@ -132,7 +132,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:hint="@string/login_identity_password"
-                android:inputType="textPassword" />
+                android:inputType="textPassword"
+                android:imeOptions="actionDone"/>
         </android.support.design.widget.TextInputLayout>
 
     </android.support.constraint.ConstraintLayout>


### PR DESCRIPTION
Description:
Cleaned up duplicate code in login process.  Added submit password directly from keyboard.

Changes:
Replaced common code, 2 from UrlLoginActivity, 2 from LoginBaseActivity, and 1 from AlternativeLoginActivity with `doLogin()`.  The intent was to preserve all functionality (not change anything).

Added listener so that the user doesn't have to first dismiss the keyboard then hit a button when logging on.  This tiny feature was where I started, but I didn't want to duplicate the code another time!

Discussion:
I realize that this is kind of a scary big set of changes, but I pulled all five instances of this duplicate code out and did a "diff".  I think I've got all the functionality intact.
