### PR TITLE
Fix bug where the creating process goes to the wrong activity.

### DIFF
--- a/app/src/main/java/org/ea/sqrl/activites/create/NewIdentityDoneActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/create/NewIdentityDoneActivity.java
@@ -9,6 +9,7 @@ import android.widget.Button;
 import android.widget.TextView;
 
 import org.ea.sqrl.R;
+import org.ea.sqrl.activites.SimplifiedActivity;
 import org.ea.sqrl.activites.UrlLoginActivity;
 import org.ea.sqrl.activites.identity.ExportOptionsActivity;
 import org.ea.sqrl.activites.MainActivity;
@@ -44,8 +45,12 @@ public class NewIdentityDoneActivity extends LoginBaseActivity {
         final Button btnNewIdentityDone = findViewById(R.id.btnNewIdentityDone);
         btnNewIdentityDone.setOnClickListener(
                 v -> {
-                    this.finish();
-                    startActivity(new Intent(this, MainActivity.class));
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                        this.finishAndRemoveTask();
+                    } else {
+                        this.finishAffinity();
+                    }
+                    startActivity(new Intent(this, SimplifiedActivity.class));
                 }
         );
     }


### PR DESCRIPTION
Issue #280 .

Description:
When you created your first identity and press back you should close app. 
Today you can go back to the introduction screen. Should not be available when identity is present.

Changes:
Close current activity and all other running activities and then fire up the simplified view so we end up in the same state as when you open the app with identities loaded.