### PR TITLE
Don't delete quickpass on network errors.

### DIFF
--- a/app/src/main/java/org/ea/sqrl/activites/CPSMissingActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/CPSMissingActivity.java
@@ -38,7 +38,6 @@ public class CPSMissingActivity  extends LoginBaseActivity {
 
         communicationFlowHandler.setErrorAction(() -> {
             storage.clear();
-            storage.clearQuickPass();
             handler.post(() -> hideProgressPopup());
         });
 

--- a/app/src/main/java/org/ea/sqrl/activites/SimplifiedActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/SimplifiedActivity.java
@@ -165,7 +165,6 @@ public class SimplifiedActivity extends LoginBaseActivity {
 
                                     communicationFlowHandler.setErrorAction(() -> {
                                         storage.clear();
-                                        storage.clearQuickPass();
                                         handler.post(() -> hideProgressPopup());
                                     });
 

--- a/app/src/main/java/org/ea/sqrl/activites/UrlLoginActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/UrlLoginActivity.java
@@ -154,7 +154,6 @@ public class UrlLoginActivity extends LoginBaseActivity {
 
                         communicationFlowHandler.setErrorAction(() -> {
                             storage.clear();
-                            storage.clearQuickPass();
                             handler.post(() -> hideProgressPopup());
                         });
 


### PR DESCRIPTION
Issue #272.

Description:
When a user logs in and a network or server error occurs the users quickpass is cleared.

Changes:
Don't clear quickpass when network or server error occurs.
