### PR TITLE
Remove fixed height in login popup

### DIFF
--- a/app/src/main/res/layout/fragment_login.xml
+++ b/app/src/main/res/layout/fragment_login.xml
@@ -9,7 +9,7 @@
     <android.support.constraint.ConstraintLayout
         android:id="@+id/constraintLayout2"
         android:layout_width="match_parent"
-        android:layout_height="371dp"
+        android:layout_height="0dp"
         android:layout_marginStart="16dp"
         android:layout_marginTop="64dp"
         android:layout_marginEnd="16dp"


### PR DESCRIPTION
Issue #291

Description:
Removed fixed height.

Changes:
Removed fixed height in logon layout popup.  The problem was that the user had configured the OS to use largest fonts.
