### PR TITLE
Deploy password strength meter

### DIFF
--- a/app/src/main/java/org/ea/sqrl/activites/identity/ChangePasswordActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/identity/ChangePasswordActivity.java
@@ -3,11 +3,13 @@ package org.ea.sqrl.activites.identity;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.view.ViewGroup;
 import android.widget.EditText;
 
 import org.ea.sqrl.R;
 import org.ea.sqrl.activites.base.BaseActivity;
 import org.ea.sqrl.processors.SQRLStorage;
+import org.ea.sqrl.utils.PasswordStrengthMeter;
 
 public class ChangePasswordActivity extends BaseActivity {
 
@@ -22,6 +24,10 @@ public class ChangePasswordActivity extends BaseActivity {
         final EditText txtCurrentPassword = findViewById(R.id.txtCurrentPassword);
         final EditText txtNewPassword = findViewById(R.id.txtNewPassword);
         final EditText txtRetypePassword = findViewById(R.id.txtRetypePassword);
+        final ViewGroup pwStrengthMeter = findViewById(R.id.passwordStrengthMeter);
+
+        new PasswordStrengthMeter(this)
+                .register(txtNewPassword, pwStrengthMeter);
 
         SQRLStorage storage = SQRLStorage.getInstance(ChangePasswordActivity.this.getApplicationContext());
 

--- a/app/src/main/java/org/ea/sqrl/activites/identity/ResetPasswordActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/identity/ResetPasswordActivity.java
@@ -4,12 +4,16 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.view.View;
+import android.view.ViewGroup;
 import android.widget.EditText;
+import android.widget.TextView;
 
 import org.ea.sqrl.R;
 import org.ea.sqrl.activites.SimplifiedActivity;
 import org.ea.sqrl.activites.base.BaseActivity;
 import org.ea.sqrl.processors.SQRLStorage;
+import org.ea.sqrl.utils.PasswordStrengthMeter;
 
 public class ResetPasswordActivity extends BaseActivity {
 
@@ -30,7 +34,15 @@ public class ResetPasswordActivity extends BaseActivity {
         final EditText txtRecoverCode5 = findViewById(R.id.txtRecoverCode5);
         final EditText txtRecoverCode6 = findViewById(R.id.txtRecoverCode6);
         final EditText txtResetPasswordNewPassword = findViewById(R.id.txtResetPasswordNewPassword);
+        final TextView txtResetPasswordDescription = findViewById(R.id.txtResetPasswordDescription);
+        final ViewGroup pwStrengthMeter = findViewById(R.id.passwordStrengthMeter);
 
+        new PasswordStrengthMeter(this)
+                .register(txtResetPasswordNewPassword, pwStrengthMeter);
+
+        txtResetPasswordNewPassword.setOnFocusChangeListener((v, hasFocus) -> {
+            txtResetPasswordDescription.setVisibility(hasFocus ? View.GONE : View.VISIBLE);
+        });
         txtRecoverCode1.requestFocus();
 
         findViewById(R.id.btnResetPassword).setOnClickListener(v -> {

--- a/app/src/main/res/layout/activity_change_password.xml
+++ b/app/src/main/res/layout/activity_change_password.xml
@@ -40,7 +40,7 @@
         android:layout_height="48dp"
         android:layout_marginEnd="16dp"
         android:layout_marginStart="16dp"
-        android:layout_marginTop="8dp"
+        android:layout_marginTop="0dp"
         android:ems="10"
         android:hint="@string/change_password_retype"
         android:inputType="textPassword"
@@ -64,5 +64,16 @@
         app:layout_constraintHorizontal_bias="0.504"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/txtCurrentPassword" />
+
+    <include layout="@layout/password_strength_meter"
+        android:id="@+id/passwordStrengthMeter"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="8dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/txtRetypePassword" />
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/activity_reset_password.xml
+++ b/app/src/main/res/layout/activity_reset_password.xml
@@ -7,7 +7,7 @@
     tools:context="org.ea.sqrl.activites.identity.ResetPasswordActivity">
 
     <TextView
-        android:id="@+id/textView14"
+        android:id="@+id/txtResetPasswordDescription"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginEnd="8dp"
@@ -85,7 +85,7 @@
         android:layoutDirection="ltr"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/textView14">
+        app:layout_constraintTop_toBottomOf="@+id/txtResetPasswordDescription">
 
         <EditText
             android:id="@+id/txtRecoverCode1"
@@ -152,6 +152,17 @@
             android:hint="@string/reset_password_new"
             android:inputType="textPassword"/>
     </android.support.design.widget.TextInputLayout>
+
+    <include layout="@layout/password_strength_meter"
+        android:id="@+id/passwordStrengthMeter"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="0dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/txtResetPasswordNewPasswordLayout" />
 
     <Button
         android:id="@+id/btnResetPassword"


### PR DESCRIPTION
Issue #278 (follow-up PR).

Description:
Deploy password strength meter to ChangePasswordActivity and ResetPasswordActivity.

Notes:
In ResetPasswordActivity, I hide the descriptive text at the top as soon as the password field gets focus, in order to gain some screen real estate. Otherwise, the strength meter is being concealed by the soft keyboard on smaller resolutions. I have tried different things to mitigate this, but found this to be the best solution overall. If anyone has a better idea, I'd be more than happy to hear about it. Thanks!