### PR TITLE
Consolidate rescue code layout and code

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -59,7 +59,7 @@
 
         <activity android:name=".activites.create.RescueCodeShowActivity"
             android:label="@string/title_rescuecode_show"
-            android:windowSoftInputMode="stateHidden"
+            android:windowSoftInputMode="stateAlwaysHidden"
             />
 
         <activity android:name=".activites.create.RescueCodeEnterActivity"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -59,6 +59,7 @@
 
         <activity android:name=".activites.create.RescueCodeShowActivity"
             android:label="@string/title_rescuecode_show"
+            android:windowSoftInputMode="stateHidden"
             />
 
         <activity android:name=".activites.create.RescueCodeEnterActivity"

--- a/app/src/main/java/org/ea/sqrl/activites/account/EnableAccountActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/account/EnableAccountActivity.java
@@ -4,12 +4,15 @@ import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
 import android.widget.EditText;
 
 import org.ea.sqrl.R;
 import org.ea.sqrl.activites.base.BaseActivity;
 import org.ea.sqrl.processors.CommunicationFlowHandler;
 import org.ea.sqrl.processors.SQRLStorage;
+import org.ea.sqrl.utils.RescueCodeInputHelper;
 
 public class EnableAccountActivity extends BaseActivity {
     private static final String TAG = "EnableAccountActivity";
@@ -26,35 +29,26 @@ public class EnableAccountActivity extends BaseActivity {
         setupProgressPopupWindow(getLayoutInflater());
         setupErrorPopupWindow(getLayoutInflater());
 
-        final EditText txtRecoverCode1 = findViewById(R.id.txtRecoverCode1);
-        final EditText txtRecoverCode2 = findViewById(R.id.txtRecoverCode2);
-        final EditText txtRecoverCode3 = findViewById(R.id.txtRecoverCode3);
-        final EditText txtRecoverCode4 = findViewById(R.id.txtRecoverCode4);
-        final EditText txtRecoverCode5 = findViewById(R.id.txtRecoverCode5);
-        final EditText txtRecoverCode6 = findViewById(R.id.txtRecoverCode6);
+        ViewGroup rootLayout = findViewById(R.id.enableAccountActivityView);
+        Button btnEnableAccount = findViewById(R.id.btnEnableAccountEnable);
 
-        txtRecoverCode1.requestFocus();
+        RescueCodeInputHelper rescueCodeInputHelper = new RescueCodeInputHelper(
+                this, rootLayout, btnEnableAccount, false);
+        rescueCodeInputHelper.setStatusChangedListener(successfullyCompleted -> {
+            btnEnableAccount.setEnabled(successfullyCompleted);
+        });
+        rescueCodeInputHelper.requestFocus();
 
-        findViewById(R.id.btnEnableAccountEnable).setOnClickListener((View v) -> {
+        btnEnableAccount.setEnabled(false);
+
+        btnEnableAccount.setOnClickListener((View v) -> {
             SQRLStorage storage = SQRLStorage.getInstance(EnableAccountActivity.this.getApplicationContext());
-
-            if(!checkRescueCode(txtRecoverCode1)) return;
-            if(!checkRescueCode(txtRecoverCode2)) return;
-            if(!checkRescueCode(txtRecoverCode3)) return;
-            if(!checkRescueCode(txtRecoverCode4)) return;
-            if(!checkRescueCode(txtRecoverCode5)) return;
-            if(!checkRescueCode(txtRecoverCode6)) return;
 
             handler.post(() -> showProgressPopup());
 
             new Thread(() -> {
                 try {
-                    String rescueCode = txtRecoverCode1.getText().toString();
-                    rescueCode += txtRecoverCode2.getText().toString();
-                    rescueCode += txtRecoverCode3.getText().toString();
-                    rescueCode += txtRecoverCode4.getText().toString();
-                    rescueCode += txtRecoverCode5.getText().toString();
-                    rescueCode += txtRecoverCode6.getText().toString();
+                    String rescueCode = rescueCodeInputHelper.getRescueCodeInput();
 
                     boolean decryptionOk = storage.decryptUnlockKey(rescueCode);
                     if (!decryptionOk) {
@@ -70,12 +64,7 @@ public class EnableAccountActivity extends BaseActivity {
                     return;
                 } finally {
                     handler.post(() -> {
-                        txtRecoverCode1.setText("");
-                        txtRecoverCode2.setText("");
-                        txtRecoverCode3.setText("");
-                        txtRecoverCode4.setText("");
-                        txtRecoverCode5.setText("");
-                        txtRecoverCode6.setText("");
+                        rescueCodeInputHelper.clearForm();
                     });
                 }
 
@@ -103,23 +92,6 @@ public class EnableAccountActivity extends BaseActivity {
                 communicationFlowHandler.handleNextAction();
             }).start();
         });
-    }
-
-    protected boolean checkRescueCode(EditText code) {
-        if(code.length() != 4) {
-            showErrorMessage(R.string.rescue_code_incorrect_input);
-            code.requestFocus();
-            return false;
-        }
-
-        try {
-            Integer.parseInt(code.getText().toString());
-        } catch (NumberFormatException nfe) {
-            showErrorMessage(R.string.rescue_code_incorrect_input);
-            code.requestFocus();
-            return false;
-        }
-        return true;
     }
 
     protected void closeActivity() {

--- a/app/src/main/java/org/ea/sqrl/activites/create/RekeyVerifyActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/create/RekeyVerifyActivity.java
@@ -12,13 +12,14 @@ import android.widget.TextView;
 import org.ea.sqrl.R;
 import org.ea.sqrl.activites.base.LoginBaseActivity;
 import org.ea.sqrl.processors.SQRLStorage;
+import org.ea.sqrl.utils.RescueCodeInputHelper;
 
 /**
  *
  * @author Daniel Persson
  */
 public class RekeyVerifyActivity extends LoginBaseActivity {
-    private static final String TAG = "RekeyIdentityActivity";
+    private static final String TAG = "RekeyVerifyActivity";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -32,34 +33,26 @@ public class RekeyVerifyActivity extends LoginBaseActivity {
         setupErrorPopupWindow(getLayoutInflater());
 
         rootView = findViewById(R.id.rekeyVerifyActivityView);
-
         final TextView txtTooManyRekey = findViewById(R.id.txtTooManyRekey);
+        final Button btnRekeyIdentityStart = findViewById(R.id.btnRekeyIdentityStart);
+
+        RescueCodeInputHelper rescueCodeInputHelper = new RescueCodeInputHelper(
+                this, rootView, btnRekeyIdentityStart, false);
+        rescueCodeInputHelper.setStatusChangedListener(successfullyCompleted -> {
+            btnRekeyIdentityStart.setEnabled(successfullyCompleted);
+        });
+
         if(storage.hasAllPreviousKeys()) {
             txtTooManyRekey.setVisibility(View.VISIBLE);
         }
 
-
-        final EditText txtRecoverCode1 = findViewById(R.id.txtRecoverCode1);
-        final EditText txtRecoverCode2 = findViewById(R.id.txtRecoverCode2);
-        final EditText txtRecoverCode3 = findViewById(R.id.txtRecoverCode3);
-        final EditText txtRecoverCode4 = findViewById(R.id.txtRecoverCode4);
-        final EditText txtRecoverCode5 = findViewById(R.id.txtRecoverCode5);
-        final EditText txtRecoverCode6 = findViewById(R.id.txtRecoverCode6);
-
-        final Button btnRekeyIdentityStart = findViewById(R.id.btnRekeyIdentityStart);
+        btnRekeyIdentityStart.setEnabled(false);
         btnRekeyIdentityStart.setOnClickListener(
                 v -> {
                     handler.post(() -> showProgressPopup());
 
                     new Thread(() -> {
-                        String rescueCode = "";
-                        rescueCode += txtRecoverCode1.getText().toString();
-                        rescueCode += txtRecoverCode2.getText().toString();
-                        rescueCode += txtRecoverCode3.getText().toString();
-                        rescueCode += txtRecoverCode4.getText().toString();
-                        rescueCode += txtRecoverCode5.getText().toString();
-                        rescueCode += txtRecoverCode6.getText().toString();
-
+                        String rescueCode = rescueCodeInputHelper.getRescueCodeInput();
                         boolean decryptRescueCode = storage.decryptUnlockKey(rescueCode);
                         if (!decryptRescueCode) {
                             Log.e(TAG, "Incorrect decryptRescue");

--- a/app/src/main/java/org/ea/sqrl/activites/create/RescueCodeEnterActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/create/RescueCodeEnterActivity.java
@@ -29,12 +29,11 @@ public class RescueCodeEnterActivity extends AppCompatActivity {
         ViewGroup rootLayout = findViewById(R.id.rescueCodeEntryActivityView);
         Button btnRescueCodeEnterNext = findViewById(R.id.btnRescueCodeEnterNext);
 
-        RescueCodeInputHelper rescueCodeInputHelper = new RescueCodeInputHelper(this);
-        rescueCodeInputHelper.setDisplayErrors(true);
+        RescueCodeInputHelper rescueCodeInputHelper = new RescueCodeInputHelper(
+                this, rootLayout, btnRescueCodeEnterNext, true);
         rescueCodeInputHelper.setStatusChangedListener(successfullyCompleted -> {
             btnRescueCodeEnterNext.setEnabled(successfullyCompleted);
         });
-        rescueCodeInputHelper.register(rootLayout, btnRescueCodeEnterNext);
 
         btnRescueCodeEnterNext.setEnabled(false);
         btnRescueCodeEnterNext.setOnClickListener(v -> {

--- a/app/src/main/java/org/ea/sqrl/activites/create/RescueCodeEnterActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/create/RescueCodeEnterActivity.java
@@ -4,16 +4,12 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.app.AppCompatDelegate;
-import android.text.Editable;
-import android.text.TextWatcher;
+import android.view.ViewGroup;
 import android.widget.Button;
-import android.widget.EditText;
 
 import org.ea.sqrl.R;
-import org.ea.sqrl.processors.SQRLStorage;
+import org.ea.sqrl.utils.RescueCodeInputHelper;
 import org.ea.sqrl.utils.Utils;
-
-import java.util.List;
 
 /**
  *
@@ -21,13 +17,6 @@ import java.util.List;
  */
 public class RescueCodeEnterActivity extends AppCompatActivity {
     private static final String TAG = "RescueCodeEnterActivity";
-    private EditText txtRecoverCode1;
-    private EditText txtRecoverCode2;
-    private EditText txtRecoverCode3;
-    private EditText txtRecoverCode4;
-    private EditText txtRecoverCode5;
-    private EditText txtRecoverCode6;
-    private Button btnRescueCodeEnterNext;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -37,14 +26,16 @@ public class RescueCodeEnterActivity extends AppCompatActivity {
 
         Utils.setLanguage(this);
 
-        txtRecoverCode1 = findViewById(R.id.txtRecoverCode1);
-        txtRecoverCode2 = findViewById(R.id.txtRecoverCode2);
-        txtRecoverCode3 = findViewById(R.id.txtRecoverCode3);
-        txtRecoverCode4 = findViewById(R.id.txtRecoverCode4);
-        txtRecoverCode5 = findViewById(R.id.txtRecoverCode5);
-        txtRecoverCode6 = findViewById(R.id.txtRecoverCode6);
+        ViewGroup rootLayout = findViewById(R.id.rescueCodeEntryActivityView);
+        Button btnRescueCodeEnterNext = findViewById(R.id.btnRescueCodeEnterNext);
 
-        btnRescueCodeEnterNext = findViewById(R.id.btnRescueCodeEnterNext);
+        RescueCodeInputHelper rescueCodeInputHelper = new RescueCodeInputHelper(this);
+        rescueCodeInputHelper.setDisplayErrors(true);
+        rescueCodeInputHelper.setStatusChangedListener(successfullyCompleted -> {
+            btnRescueCodeEnterNext.setEnabled(successfullyCompleted);
+        });
+        rescueCodeInputHelper.register(rootLayout, btnRescueCodeEnterNext);
+
         btnRescueCodeEnterNext.setEnabled(false);
         btnRescueCodeEnterNext.setOnClickListener(v -> {
             this.finish();
@@ -53,52 +44,5 @@ public class RescueCodeEnterActivity extends AppCompatActivity {
 
         boolean runningTest = getIntent().getBooleanExtra("RUNNING_TEST", false);
         if(runningTest) return;
-
-        SQRLStorage storage = SQRLStorage.getInstance(RescueCodeEnterActivity.this.getApplicationContext());
-        List<String> rescueList = storage.getTempShowableRescueCode();
-
-        setListener(txtRecoverCode1, rescueList);
-        setListener(txtRecoverCode2, rescueList);
-        setListener(txtRecoverCode3, rescueList);
-        setListener(txtRecoverCode4, rescueList);
-        setListener(txtRecoverCode5, rescueList);
-        setListener(txtRecoverCode6, rescueList);
-
-    }
-
-    private void setListener(EditText code, List<String> rescueList) {
-        code.addTextChangedListener(new TextWatcher() {
-            @Override
-            public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
-
-            @Override
-            public void onTextChanged(CharSequence s, int start, int before, int count) {
-                if(s.length() == 4) {
-                    boolean incorrect =
-                            checkEditText(txtRecoverCode1, rescueList.get(0)) ||
-                            checkEditText(txtRecoverCode2, rescueList.get(1)) ||
-                            checkEditText(txtRecoverCode3, rescueList.get(2)) ||
-                            checkEditText(txtRecoverCode4, rescueList.get(3)) ||
-                            checkEditText(txtRecoverCode5, rescueList.get(4)) ||
-                            checkEditText(txtRecoverCode6, rescueList.get(5));
-                    btnRescueCodeEnterNext.setEnabled(!incorrect);
-                }
-            }
-
-            @Override
-            public void afterTextChanged(Editable s) {}
-        });
-    }
-
-    private boolean checkEditText(EditText code, String verify) {
-        if (code.getText().toString().equals(verify)) {
-            code.setError(null);
-            return false;
-        } else {
-            if(code.getText().length() > 0) {
-                code.setError("Incorrect");
-            }
-            return true;
-        }
     }
 }

--- a/app/src/main/java/org/ea/sqrl/activites/create/RescueCodeShowActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/create/RescueCodeShowActivity.java
@@ -10,13 +10,17 @@ import android.print.PrintManager;
 
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.app.AppCompatDelegate;
+import android.text.method.LinkMovementMethod;
 import android.util.Log;
+import android.view.ViewGroup;
+import android.widget.Button;
 import android.widget.TextView;
 
 import org.ea.sqrl.R;
 import org.ea.sqrl.processors.EntropyHarvester;
 import org.ea.sqrl.processors.SQRLStorage;
 import org.ea.sqrl.services.RescueCodePrintDocumentAdapter;
+import org.ea.sqrl.utils.RescueCodeInputHelper;
 import org.ea.sqrl.utils.Utils;
 
 import java.util.List;
@@ -43,19 +47,16 @@ public class RescueCodeShowActivity extends AppCompatActivity {
 
             List<String> rescueArr = storage.getTempShowableRescueCode();
 
-            final TextView txtRecoverCode1 = findViewById(R.id.txtRecoverCode1);
-            final TextView txtRecoverCode2 = findViewById(R.id.txtRecoverCode2);
-            final TextView txtRecoverCode3 = findViewById(R.id.txtRecoverCode3);
-            final TextView txtRecoverCode4 = findViewById(R.id.txtRecoverCode4);
-            final TextView txtRecoverCode5 = findViewById(R.id.txtRecoverCode5);
-            final TextView txtRecoverCode6 = findViewById(R.id.txtRecoverCode6);
+            final TextView txtRescueCodeShowDescription = findViewById(R.id.txtRescueCodeShowDescription);
+            final ViewGroup rootView = findViewById(R.id.rescueCodeShowActivityView);
+            final Button btnRescueCodeShowNext = findViewById(R.id.btnRescueCodeShowNext);
 
-            txtRecoverCode1.setText(rescueArr.get(0));
-            txtRecoverCode2.setText(rescueArr.get(1));
-            txtRecoverCode3.setText(rescueArr.get(2));
-            txtRecoverCode4.setText(rescueArr.get(3));
-            txtRecoverCode5.setText(rescueArr.get(4));
-            txtRecoverCode6.setText(rescueArr.get(5));
+            txtRescueCodeShowDescription.setMovementMethod(LinkMovementMethod.getInstance());
+
+            RescueCodeInputHelper rescueCodeInputHelper = new RescueCodeInputHelper(
+                    this, rootView, btnRescueCodeShowNext, false);
+            rescueCodeInputHelper.setInputEnabled(false);
+            rescueCodeInputHelper.setRescueCodeInput(rescueArr);
 
         } catch (Exception e) {
             Log.e(TAG, e.getMessage(), e);

--- a/app/src/main/java/org/ea/sqrl/activites/identity/ResetPasswordActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/identity/ResetPasswordActivity.java
@@ -6,6 +6,7 @@ import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
 
@@ -14,6 +15,7 @@ import org.ea.sqrl.activites.SimplifiedActivity;
 import org.ea.sqrl.activites.base.BaseActivity;
 import org.ea.sqrl.processors.SQRLStorage;
 import org.ea.sqrl.utils.PasswordStrengthMeter;
+import org.ea.sqrl.utils.RescueCodeInputHelper;
 
 public class ResetPasswordActivity extends BaseActivity {
 
@@ -27,15 +29,11 @@ public class ResetPasswordActivity extends BaseActivity {
         setupProgressPopupWindow(getLayoutInflater());
         setupErrorPopupWindow(getLayoutInflater());
 
-        final EditText txtRecoverCode1 = findViewById(R.id.txtRecoverCode1);
-        final EditText txtRecoverCode2 = findViewById(R.id.txtRecoverCode2);
-        final EditText txtRecoverCode3 = findViewById(R.id.txtRecoverCode3);
-        final EditText txtRecoverCode4 = findViewById(R.id.txtRecoverCode4);
-        final EditText txtRecoverCode5 = findViewById(R.id.txtRecoverCode5);
-        final EditText txtRecoverCode6 = findViewById(R.id.txtRecoverCode6);
         final EditText txtResetPasswordNewPassword = findViewById(R.id.txtResetPasswordNewPassword);
         final TextView txtResetPasswordDescription = findViewById(R.id.txtResetPasswordDescription);
         final ViewGroup pwStrengthMeter = findViewById(R.id.passwordStrengthMeter);
+        final ViewGroup rootView = findViewById(R.id.resetPasswordActivityView);
+        final Button btnResetPassword = findViewById(R.id.btnResetPassword);
 
         new PasswordStrengthMeter(this)
                 .register(txtResetPasswordNewPassword, pwStrengthMeter);
@@ -43,28 +41,23 @@ public class ResetPasswordActivity extends BaseActivity {
         txtResetPasswordNewPassword.setOnFocusChangeListener((v, hasFocus) -> {
             txtResetPasswordDescription.setVisibility(hasFocus ? View.GONE : View.VISIBLE);
         });
-        txtRecoverCode1.requestFocus();
 
-        findViewById(R.id.btnResetPassword).setOnClickListener(v -> {
+        RescueCodeInputHelper rescueCodeInputHelper = new RescueCodeInputHelper(
+                this, rootView, txtResetPasswordNewPassword, false);
+        rescueCodeInputHelper.setStatusChangedListener(successfullyCompleted -> {
+            btnResetPassword.setEnabled(successfullyCompleted);
+        });
+        rescueCodeInputHelper.requestFocus();
+
+        btnResetPassword.setEnabled(false);
+        btnResetPassword.setOnClickListener(v -> {
 
             SQRLStorage storage = SQRLStorage.getInstance(ResetPasswordActivity.this.getApplicationContext());
-
-            if(!checkRescueCode(txtRecoverCode1)) return;
-            if(!checkRescueCode(txtRecoverCode2)) return;
-            if(!checkRescueCode(txtRecoverCode3)) return;
-            if(!checkRescueCode(txtRecoverCode4)) return;
-            if(!checkRescueCode(txtRecoverCode5)) return;
-            if(!checkRescueCode(txtRecoverCode6)) return;
 
             showProgressPopup();
 
             new Thread(() -> {
-                String rescueCode = txtRecoverCode1.getText().toString();
-                rescueCode += txtRecoverCode2.getText().toString();
-                rescueCode += txtRecoverCode3.getText().toString();
-                rescueCode += txtRecoverCode4.getText().toString();
-                rescueCode += txtRecoverCode5.getText().toString();
-                rescueCode += txtRecoverCode6.getText().toString();
+                String rescueCode = rescueCodeInputHelper.getRescueCodeInput();
 
                 boolean decryptionOk = storage.decryptUnlockKey(rescueCode);
                 if (!decryptionOk) {
@@ -92,12 +85,7 @@ public class ResetPasswordActivity extends BaseActivity {
                 handler.post(() -> {
                     hideProgressPopup();
                     txtResetPasswordNewPassword.setText("");
-                    txtRecoverCode1.setText("");
-                    txtRecoverCode2.setText("");
-                    txtRecoverCode3.setText("");
-                    txtRecoverCode4.setText("");
-                    txtRecoverCode5.setText("");
-                    txtRecoverCode6.setText("");
+                    rescueCodeInputHelper.clearForm();
                 });
 
                 if(mDbHelper.hasIdentities() && !newIdentity) {
@@ -127,22 +115,4 @@ public class ResetPasswordActivity extends BaseActivity {
             }).start();
         });
     }
-
-    protected boolean checkRescueCode(EditText code) {
-        if(code.length() != 4) {
-            showErrorMessage(R.string.rescue_code_incorrect_input);
-            code.requestFocus();
-            return false;
-        }
-
-        try {
-            Integer.parseInt(code.getText().toString());
-        } catch (NumberFormatException nfe) {
-            showErrorMessage(R.string.rescue_code_incorrect_input);
-            code.requestFocus();
-            return false;
-        }
-        return true;
-    }
-
 }

--- a/app/src/main/java/org/ea/sqrl/utils/RescueCodeInputHelper.java
+++ b/app/src/main/java/org/ea/sqrl/utils/RescueCodeInputHelper.java
@@ -35,7 +35,9 @@ public class RescueCodeInputHelper {
     private EditText mTxtRecoverCode5;
     private EditText mTxtRecoverCode6;
     private SQRLStorage mSqrlStorage;
+    private List<String> mRescueList;
     private boolean mDisplayErrors = false;
+    private boolean mLastStatus = false;
     private StatusChangedListener mStatusChangedListener;
 
 
@@ -48,6 +50,7 @@ public class RescueCodeInputHelper {
 
         mContext = context;
         mSqrlStorage = SQRLStorage.getInstance(mContext);
+        mRescueList = mSqrlStorage.getTempShowableRescueCode();
     }
 
     /**
@@ -72,14 +75,12 @@ public class RescueCodeInputHelper {
             mTxtRecoverCode6.setNextFocusDownId(nextFocusDown.getId());
         }
 
-        List<String> rescueList = mSqrlStorage.getTempShowableRescueCode();
-
-        setEditTextListener(mTxtRecoverCode1, rescueList);
-        setEditTextListener(mTxtRecoverCode2, rescueList);
-        setEditTextListener(mTxtRecoverCode3, rescueList);
-        setEditTextListener(mTxtRecoverCode4, rescueList);
-        setEditTextListener(mTxtRecoverCode5, rescueList);
-        setEditTextListener(mTxtRecoverCode6, rescueList);
+        setListener(mTxtRecoverCode1);
+        setListener(mTxtRecoverCode2);
+        setListener(mTxtRecoverCode3);
+        setListener(mTxtRecoverCode4);
+        setListener(mTxtRecoverCode5);
+        setListener(mTxtRecoverCode6);
     }
 
     /**
@@ -102,7 +103,22 @@ public class RescueCodeInputHelper {
         mStatusChangedListener = listener;
     }
 
-    private void setEditTextListener(EditText code, List<String> rescueList) {
+    /**
+     * Checks if the rescue code input is complete and correct.
+     *
+     * @return True if the rescue code input is complete and correct, false otherwise.
+     */
+    public boolean getStatus() {
+
+        return checkEditText(mTxtRecoverCode1, mRescueList.get(0)) &&
+            checkEditText(mTxtRecoverCode2, mRescueList.get(1)) &&
+            checkEditText(mTxtRecoverCode3, mRescueList.get(2)) &&
+            checkEditText(mTxtRecoverCode4, mRescueList.get(3)) &&
+            checkEditText(mTxtRecoverCode5, mRescueList.get(4)) &&
+            checkEditText(mTxtRecoverCode6, mRescueList.get(5));
+    }
+
+    private void setListener(EditText code) {
 
         code.addTextChangedListener(new TextWatcher() {
 
@@ -114,15 +130,13 @@ public class RescueCodeInputHelper {
             @Override
             public void onTextChanged(CharSequence s, int start, int before, int count) {
 
-                boolean correct =
-                        checkEditText(mTxtRecoverCode1, rescueList.get(0)) &&
-                        checkEditText(mTxtRecoverCode2, rescueList.get(1)) &&
-                        checkEditText(mTxtRecoverCode3, rescueList.get(2)) &&
-                        checkEditText(mTxtRecoverCode4, rescueList.get(3)) &&
-                        checkEditText(mTxtRecoverCode5, rescueList.get(4)) &&
-                        checkEditText(mTxtRecoverCode6, rescueList.get(5));
-                if(mStatusChangedListener != null) {
-                    mStatusChangedListener.onEvent(correct);
+                boolean status = getStatus();
+
+                if (status != mLastStatus) {
+                    if(mStatusChangedListener != null) {
+                        mStatusChangedListener.onEvent(status);
+                    }
+                    mLastStatus = status;
                 }
             }
         });

--- a/app/src/main/java/org/ea/sqrl/utils/RescueCodeInputHelper.java
+++ b/app/src/main/java/org/ea/sqrl/utils/RescueCodeInputHelper.java
@@ -150,6 +150,36 @@ public class RescueCodeInputHelper {
         mTxtRecoverCode6.setText("");
     }
 
+    /**
+     * Fills the given rescue code into the input form.
+     *
+     * @param rescueArr A list containing the six parts of the rescue code.
+     */
+    public void setRescueCodeInput(List<String> rescueArr) {
+
+        mTxtRecoverCode1.setText(rescueArr.get(0));
+        mTxtRecoverCode2.setText(rescueArr.get(1));
+        mTxtRecoverCode3.setText(rescueArr.get(2));
+        mTxtRecoverCode4.setText(rescueArr.get(3));
+        mTxtRecoverCode5.setText(rescueArr.get(4));
+        mTxtRecoverCode6.setText(rescueArr.get(5));
+    }
+
+    /**
+     * Enable or disable form input.
+     *
+     * @param enabled Set to true if form input should be enabled, otherwise set to false.
+     */
+    public void setInputEnabled(boolean enabled) {
+
+        mTxtRecoverCode1.setEnabled(enabled);
+        mTxtRecoverCode2.setEnabled(enabled);
+        mTxtRecoverCode3.setEnabled(enabled);
+        mTxtRecoverCode4.setEnabled(enabled);
+        mTxtRecoverCode5.setEnabled(enabled);
+        mTxtRecoverCode6.setEnabled(enabled);
+    }
+
     private void setListener(EditText code) {
 
         code.addTextChangedListener(new TextWatcher() {

--- a/app/src/main/java/org/ea/sqrl/utils/RescueCodeInputHelper.java
+++ b/app/src/main/java/org/ea/sqrl/utils/RescueCodeInputHelper.java
@@ -1,0 +1,149 @@
+package org.ea.sqrl.utils;
+
+import android.content.Context;
+import android.support.annotation.Nullable;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.EditText;
+
+import org.ea.sqrl.R;
+import org.ea.sqrl.processors.SQRLStorage;
+
+import java.util.List;
+
+/**
+ * Helper class for handling rescue code input and validation.
+ * Expects the rescue_code_input.xml to be present in the calling layout
+ *
+ * @author Alexander Hauser (alexhauser)
+ */
+public class RescueCodeInputHelper {
+
+    public interface StatusChangedListener {
+        void onEvent(boolean successfullyCompleted);
+    }
+
+    private static final String TAG = "RescueCodeInputHelper";
+    private Context mContext;
+    private ViewGroup mLayoutRoot;
+    private EditText mTxtRecoverCode1;
+    private EditText mTxtRecoverCode2;
+    private EditText mTxtRecoverCode3;
+    private EditText mTxtRecoverCode4;
+    private EditText mTxtRecoverCode5;
+    private EditText mTxtRecoverCode6;
+    private SQRLStorage mSqrlStorage;
+    private boolean mDisplayErrors = false;
+    private StatusChangedListener mStatusChangedListener;
+
+
+    /**
+     * Creates a RescueCodeInputHelper object.
+     *
+     * @param context The context of the caller.
+     */
+    public RescueCodeInputHelper (Context context) {
+
+        mContext = context;
+        mSqrlStorage = SQRLStorage.getInstance(mContext);
+    }
+
+    /**
+     * Registers the RescueCodeInputHelper to set event handlers on the rescue code input form
+     * and enables the corresponding events.
+     *
+     * @param rootLayout The root layout containing the rescue_code_input layout as well as the nextFocusDown view.
+     * @param nextFocusDown The View that should receive focus after the last rescue code field has been filled out.
+     */
+    public void register(ViewGroup rootLayout, @Nullable View nextFocusDown) {
+
+        mLayoutRoot = rootLayout;
+
+        mTxtRecoverCode1 = mLayoutRoot.findViewById(R.id.txtRecoverCode1);
+        mTxtRecoverCode2 = mLayoutRoot.findViewById(R.id.txtRecoverCode2);
+        mTxtRecoverCode3 = mLayoutRoot.findViewById(R.id.txtRecoverCode3);
+        mTxtRecoverCode4 = mLayoutRoot.findViewById(R.id.txtRecoverCode4);
+        mTxtRecoverCode5 = mLayoutRoot.findViewById(R.id.txtRecoverCode5);
+        mTxtRecoverCode6 = mLayoutRoot.findViewById(R.id.txtRecoverCode6);
+
+        if (nextFocusDown != null) {
+            mTxtRecoverCode6.setNextFocusDownId(nextFocusDown.getId());
+        }
+
+        List<String> rescueList = mSqrlStorage.getTempShowableRescueCode();
+
+        setEditTextListener(mTxtRecoverCode1, rescueList);
+        setEditTextListener(mTxtRecoverCode2, rescueList);
+        setEditTextListener(mTxtRecoverCode3, rescueList);
+        setEditTextListener(mTxtRecoverCode4, rescueList);
+        setEditTextListener(mTxtRecoverCode5, rescueList);
+        setEditTextListener(mTxtRecoverCode6, rescueList);
+    }
+
+    /**
+     * Enables or disables showing input errors in the input form's UI.
+     *
+     * @param displayErrors Set to true if input errors should be displayed, otherwise to false.
+     */
+    public void setDisplayErrors(boolean displayErrors) {
+
+        mDisplayErrors = displayErrors;
+    }
+
+    /**
+     * Registers a callback to be invoked when the status of the rescue code input changes.
+     *
+     * @param listener The callback method that should be executed.
+     */
+    public void setStatusChangedListener(StatusChangedListener listener) {
+
+        mStatusChangedListener = listener;
+    }
+
+    private void setEditTextListener(EditText code, List<String> rescueList) {
+
+        code.addTextChangedListener(new TextWatcher() {
+
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+            @Override
+            public void afterTextChanged(Editable s) {}
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+
+                boolean correct =
+                        checkEditText(mTxtRecoverCode1, rescueList.get(0)) &&
+                        checkEditText(mTxtRecoverCode2, rescueList.get(1)) &&
+                        checkEditText(mTxtRecoverCode3, rescueList.get(2)) &&
+                        checkEditText(mTxtRecoverCode4, rescueList.get(3)) &&
+                        checkEditText(mTxtRecoverCode5, rescueList.get(4)) &&
+                        checkEditText(mTxtRecoverCode6, rescueList.get(5));
+                if(mStatusChangedListener != null) {
+                    mStatusChangedListener.onEvent(correct);
+                }
+            }
+        });
+    }
+
+    private boolean checkEditText(EditText code, String verify) {
+
+        String check = code.getText().toString();
+        if(check.length() != 4) return false;
+
+        if (check.equals(verify)) {
+            code.setError(null);
+            View nextFocusDown = mLayoutRoot.findViewById(code.getNextFocusDownId());
+            if (nextFocusDown != null) nextFocusDown.requestFocus();
+            return true;
+        } else {
+            if(mDisplayErrors) {
+                code.setError(mContext.getResources().getString(
+                        R.string.rescue_code_incorrect));
+            }
+            return false;
+        }
+    }
+}

--- a/app/src/main/res/layout-land/activity_rescuecode_show.xml
+++ b/app/src/main/res/layout-land/activity_rescuecode_show.xml
@@ -7,111 +7,30 @@
     android:id="@+id/rescueCodeShowActivityView"
     tools:context="org.ea.sqrl.activites.create.RescueCodeShowActivity">
 
-    <android.support.constraint.ConstraintLayout
-        android:id="@+id/inputRow1"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="8dp"
-        android:layout_marginStart="8dp"
+    <TextView
+        android:id="@+id/txtRescueCodeShowDescription"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginStart="16dp"
         android:layout_marginTop="16dp"
-        android:focusable="false"
-        android:layoutDirection="ltr"
+        android:layout_marginEnd="16dp"
+        android:text="@string/rescuecode_show_desc"
+        app:layout_constraintBottom_toTopOf="@+id/rescueCodeInput"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/textView17">
+        app:layout_constraintTop_toTopOf="parent" />
 
-        <TextView
-            android:id="@+id/txtRecoverCode1"
-            android:layout_width="72dp"
-            android:layout_height="wrap_content"
-            android:ems="10"
-            android:nextFocusDown="@+id/txtRecoverCode2"
-            android:textAlignment="center"
-            android:textAppearance="@style/TextAppearance.AppCompat.Large"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-
-        <TextView
-            android:id="@+id/txtRecoverCode2"
-            android:layout_width="72dp"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="8dp"
-            android:layout_marginStart="8dp"
-            android:ems="10"
-            android:nextFocusDown="@+id/txtRecoverCode3"
-            android:textAlignment="center"
-            android:textAppearance="@style/TextAppearance.AppCompat.Large"
-            app:layout_constraintStart_toEndOf="@+id/txtRecoverCode1"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-
-        <TextView
-            android:id="@+id/txtRecoverCode3"
-            android:layout_width="72dp"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="8dp"
-            android:layout_marginStart="8dp"
-            android:ems="10"
-            android:nextFocusDown="@+id/txtRecoverCode4"
-            android:textAlignment="center"
-            android:textAppearance="@style/TextAppearance.AppCompat.Large"
-            app:layout_constraintStart_toEndOf="@+id/txtRecoverCode2"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-    </android.support.constraint.ConstraintLayout>
-
-    <android.support.constraint.ConstraintLayout
-        android:id="@+id/inputRow2"
-        android:layout_width="wrap_content"
+    <include
+        android:id="@+id/rescueCodeInput"
+        layout="@layout/rescue_code_input"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="8dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:focusable="false"
-        android:layoutDirection="ltr"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="8dp"
+        app:layout_constraintBottom_toTopOf="@+id/btnPrintRescueCode"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/inputRow1">
-
-        <TextView
-            android:id="@+id/txtRecoverCode4"
-            android:layout_width="72dp"
-            android:layout_height="wrap_content"
-            android:ems="10"
-            android:nextFocusDown="@+id/txtRecoverCode5"
-            android:textAlignment="center"
-            android:textAppearance="@style/TextAppearance.AppCompat.Large"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-
-        <TextView
-            android:id="@+id/txtRecoverCode5"
-            android:layout_width="72dp"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="8dp"
-            android:layout_marginStart="8dp"
-            android:ems="10"
-            android:nextFocusDown="@+id/txtRecoverCode6"
-            android:textAlignment="center"
-            android:textAppearance="@style/TextAppearance.AppCompat.Large"
-            app:layout_constraintStart_toEndOf="@+id/txtRecoverCode4"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-
-        <TextView
-            android:id="@+id/txtRecoverCode6"
-            android:layout_width="72dp"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="8dp"
-            android:layout_marginStart="8dp"
-            android:ems="10"
-            android:nextFocusDown="@+id/txtResetPasswordNewPassword"
-            android:textAlignment="center"
-            android:textAppearance="@style/TextAppearance.AppCompat.Large"
-            app:layout_constraintStart_toEndOf="@+id/txtRecoverCode5"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-    </android.support.constraint.ConstraintLayout>
+        app:layout_constraintStart_toStartOf="parent" />
 
     <Button
         android:id="@+id/btnPrintRescueCode"
@@ -135,15 +54,4 @@
         app:layout_constraintEnd_toEndOf="parent"
         android:layout_marginRight="16dp" />
 
-    <TextView
-        android:id="@+id/textView17"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="16dp"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="16dp"
-        android:text="@string/rescuecode_show_desc"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/activity_enable_account.xml
+++ b/app/src/main/res/layout/activity_enable_account.xml
@@ -6,118 +6,16 @@
     android:id="@+id/enableAccountActivityView"
     tools:context="org.ea.sqrl.activites.account.EnableAccountActivity">
 
-    <android.support.constraint.ConstraintLayout
-        android:id="@+id/inputRow2"
-        android:layout_width="wrap_content"
+    <include layout="@layout/rescue_code_input"
+        android:id="@+id/rescueCodeInput"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="8dp"
-        android:layout_marginStart="8dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginStart="16dp"
         android:layout_marginTop="8dp"
-        android:focusable="false"
-        android:layoutDirection="ltr"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/inputRow1">
-
-        <EditText
-            android:id="@+id/txtRecoverCode4"
-            android:layout_width="72dp"
-            android:layout_height="48dp"
-            android:ems="10"
-            android:hint="@string/reset_password_rescuecode_4"
-            android:inputType="phone"
-            android:maxLength="4"
-            android:nextFocusDown="@+id/txtRecoverCode5"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-
-        <EditText
-            android:id="@+id/txtRecoverCode5"
-            android:layout_width="72dp"
-            android:layout_height="48dp"
-            android:layout_marginLeft="8dp"
-            android:layout_marginStart="8dp"
-            android:ems="10"
-            android:hint="@string/reset_password_rescuecode_5"
-            android:inputType="phone"
-            android:maxLength="4"
-            android:nextFocusDown="@+id/txtRecoverCode6"
-            app:layout_constraintStart_toEndOf="@+id/txtRecoverCode4"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-
-        <EditText
-            android:id="@+id/txtRecoverCode6"
-            android:layout_width="72dp"
-            android:layout_height="48dp"
-            android:layout_marginLeft="8dp"
-            android:layout_marginStart="8dp"
-            android:ems="10"
-            android:hint="@string/reset_password_rescuecode_6"
-            android:inputType="phone"
-            android:maxLength="4"
-            android:nextFocusDown="@+id/btnEnableAccountEnable"
-            app:layout_constraintStart_toEndOf="@+id/txtRecoverCode5"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-    </android.support.constraint.ConstraintLayout>
-
-    <android.support.constraint.ConstraintLayout
-        android:id="@+id/inputRow1"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="8dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="16dp"
-        android:focusable="false"
-        android:layoutDirection="ltr"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
-
-        <EditText
-            android:id="@+id/txtRecoverCode1"
-            android:layout_width="72dp"
-            android:layout_height="48dp"
-            android:ems="10"
-            android:hint="@string/reset_password_rescuecode_1"
-            android:inputType="phone"
-            android:maxLength="4"
-            android:nextFocusDown="@+id/txtRecoverCode2"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-
-        <EditText
-            android:id="@+id/txtRecoverCode2"
-            android:layout_width="72dp"
-            android:layout_height="48dp"
-            android:layout_marginLeft="8dp"
-            android:layout_marginStart="8dp"
-            android:ems="10"
-            android:hint="@string/reset_password_rescuecode_2"
-            android:inputType="phone"
-            android:maxLength="4"
-            android:nextFocusDown="@+id/txtRecoverCode3"
-            app:layout_constraintStart_toEndOf="@+id/txtRecoverCode1"
-            app:layout_constraintTop_toTopOf="parent"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-
-        <EditText
-            android:id="@+id/txtRecoverCode3"
-            android:layout_width="72dp"
-            android:layout_height="48dp"
-            android:layout_marginLeft="8dp"
-            android:layout_marginStart="8dp"
-            android:ems="10"
-            android:hint="@string/reset_password_rescuecode_3"
-            android:inputType="phone"
-            android:maxLength="4"
-            android:nextFocusDown="@+id/txtRecoverCode4"
-            app:layout_constraintStart_toEndOf="@+id/txtRecoverCode2"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-    </android.support.constraint.ConstraintLayout>
+        app:layout_constraintTop_toTopOf="parent" />
 
     <Button
         android:id="@+id/btnEnableAccountEnable"

--- a/app/src/main/res/layout/activity_rekey_verify.xml
+++ b/app/src/main/res/layout/activity_rekey_verify.xml
@@ -7,118 +7,6 @@
     android:id="@+id/rekeyVerifyActivityView"
     tools:context="org.ea.sqrl.activites.create.RekeyVerifyActivity">
 
-    <android.support.constraint.ConstraintLayout
-        android:id="@+id/inputRow1"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="8dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:focusable="false"
-        android:layoutDirection="ltr"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/txtTooManyRekey">
-
-        <EditText
-            android:id="@+id/txtRecoverCode1"
-            android:layout_width="72dp"
-            android:layout_height="48dp"
-            android:ems="10"
-            android:hint="@string/reset_password_rescuecode_1"
-            android:inputType="phone"
-            android:maxLength="4"
-            android:nextFocusDown="@+id/txtRecoverCode2"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-
-        <EditText
-            android:id="@+id/txtRecoverCode2"
-            android:layout_width="72dp"
-            android:layout_height="48dp"
-            android:layout_marginLeft="8dp"
-            android:layout_marginStart="8dp"
-            android:ems="10"
-            android:hint="@string/reset_password_rescuecode_2"
-            android:inputType="phone"
-            android:maxLength="4"
-            android:nextFocusDown="@+id/txtRecoverCode3"
-            app:layout_constraintStart_toEndOf="@+id/txtRecoverCode1"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-
-        <EditText
-            android:id="@+id/txtRecoverCode3"
-            android:layout_width="72dp"
-            android:layout_height="48dp"
-            android:layout_marginLeft="8dp"
-            android:layout_marginStart="8dp"
-            android:ems="10"
-            android:hint="@string/reset_password_rescuecode_3"
-            android:inputType="phone"
-            android:maxLength="4"
-            android:nextFocusDown="@+id/txtRecoverCode4"
-            app:layout_constraintStart_toEndOf="@+id/txtRecoverCode2"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-    </android.support.constraint.ConstraintLayout>
-
-    <android.support.constraint.ConstraintLayout
-        android:id="@+id/inputRow2"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="8dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:focusable="false"
-        android:layoutDirection="ltr"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/inputRow1">
-
-        <EditText
-            android:id="@+id/txtRecoverCode4"
-            android:layout_width="72dp"
-            android:layout_height="48dp"
-            android:ems="10"
-            android:hint="@string/reset_password_rescuecode_4"
-            android:inputType="phone"
-            android:maxLength="4"
-            android:nextFocusDown="@+id/txtRecoverCode5"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-
-        <EditText
-            android:id="@+id/txtRecoverCode5"
-            android:layout_width="72dp"
-            android:layout_height="48dp"
-            android:layout_marginLeft="8dp"
-            android:layout_marginStart="8dp"
-            android:ems="10"
-            android:hint="@string/reset_password_rescuecode_5"
-            android:inputType="phone"
-            android:maxLength="4"
-            android:nextFocusDown="@+id/txtRecoverCode6"
-            app:layout_constraintStart_toEndOf="@+id/txtRecoverCode4"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-
-        <EditText
-            android:id="@+id/txtRecoverCode6"
-            android:layout_width="72dp"
-            android:layout_height="48dp"
-            android:layout_marginLeft="8dp"
-            android:layout_marginStart="8dp"
-            android:ems="10"
-            android:hint="@string/reset_password_rescuecode_6"
-            android:inputType="phone"
-            android:maxLength="4"
-            android:nextFocusDown="@+id/btnRekeyIdentityStart"
-            app:layout_constraintStart_toEndOf="@+id/txtRecoverCode5"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-    </android.support.constraint.ConstraintLayout>
-
     <TextView
         android:id="@+id/txtRekeyVerifyMessage"
         android:layout_width="0dp"
@@ -132,17 +20,16 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <Button
-        android:id="@+id/btnRekeyIdentityStart"
+    <include layout="@layout/rescue_code_input"
+        android:id="@+id/rescueCodeInput"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginEnd="16dp"
         android:layout_marginStart="16dp"
         android:layout_marginTop="8dp"
-        android:text="@string/button_rekey_verify_next"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/inputRow2" />
+        app:layout_constraintTop_toBottomOf="@+id/txtTooManyRekey" />
 
     <TextView
         android:id="@+id/txtTooManyRekey"
@@ -158,4 +45,17 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/txtRekeyVerifyMessage" />
+
+    <Button
+        android:id="@+id/btnRekeyIdentityStart"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="8dp"
+        android:text="@string/button_rekey_verify_next"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/rescueCodeInput" />
+
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/activity_remove_account.xml
+++ b/app/src/main/res/layout/activity_remove_account.xml
@@ -6,62 +6,16 @@
     android:id="@+id/removeAccountActivityView"
     tools:context="org.ea.sqrl.activites.account.RemoveAccountActivity">
 
-    <android.support.constraint.ConstraintLayout
-        android:id="@+id/inputRow1"
-        android:layout_width="wrap_content"
+    <include layout="@layout/rescue_code_input"
+        android:id="@+id/rescueCodeInput"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="8dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="16dp"
-        android:focusable="false"
-        android:layoutDirection="ltr"
+        android:layout_marginEnd="16dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="8dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
-
-        <EditText
-            android:id="@+id/txtRecoverCode1"
-            android:layout_width="72dp"
-            android:layout_height="48dp"
-            android:ems="10"
-            android:hint="@string/reset_password_rescuecode_1"
-            android:inputType="phone"
-            android:maxLength="4"
-            android:nextFocusDown="@+id/txtRecoverCode2"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-
-        <EditText
-            android:id="@+id/txtRecoverCode2"
-            android:layout_width="72dp"
-            android:layout_height="48dp"
-            android:layout_marginLeft="8dp"
-            android:layout_marginStart="8dp"
-            android:ems="10"
-            android:hint="@string/reset_password_rescuecode_2"
-            android:inputType="phone"
-            android:maxLength="4"
-            android:nextFocusDown="@+id/txtRecoverCode3"
-            app:layout_constraintStart_toEndOf="@+id/txtRecoverCode1"
-            app:layout_constraintTop_toTopOf="parent"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-
-        <EditText
-            android:id="@+id/txtRecoverCode3"
-            android:layout_width="72dp"
-            android:layout_height="48dp"
-            android:layout_marginLeft="8dp"
-            android:layout_marginStart="8dp"
-            android:ems="10"
-            android:hint="@string/reset_password_rescuecode_3"
-            android:inputType="phone"
-            android:maxLength="4"
-            android:nextFocusDown="@+id/txtRecoverCode4"
-            app:layout_constraintStart_toEndOf="@+id/txtRecoverCode2"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-    </android.support.constraint.ConstraintLayout>
+        app:layout_constraintTop_toTopOf="parent" />
 
     <Button
         android:id="@+id/btnRemoveAccountRemove"
@@ -77,61 +31,5 @@
         app:layout_constraintStart_toStartOf="parent"
         tools:layout_conversion_absoluteHeight="48dp"
         tools:layout_conversion_absoluteWidth="88dp" />
-
-    <android.support.constraint.ConstraintLayout
-        android:id="@+id/inputRow2"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="8dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:focusable="false"
-        android:layoutDirection="ltr"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/inputRow1">
-
-        <EditText
-            android:id="@+id/txtRecoverCode4"
-            android:layout_width="72dp"
-            android:layout_height="48dp"
-            android:ems="10"
-            android:hint="@string/reset_password_rescuecode_4"
-            android:inputType="phone"
-            android:maxLength="4"
-            android:nextFocusDown="@+id/txtRecoverCode5"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-
-        <EditText
-            android:id="@+id/txtRecoverCode5"
-            android:layout_width="72dp"
-            android:layout_height="48dp"
-            android:layout_marginLeft="8dp"
-            android:layout_marginStart="8dp"
-            android:ems="10"
-            android:hint="@string/reset_password_rescuecode_5"
-            android:inputType="phone"
-            android:maxLength="4"
-            android:nextFocusDown="@+id/txtRecoverCode6"
-            app:layout_constraintStart_toEndOf="@+id/txtRecoverCode4"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-
-        <EditText
-            android:id="@+id/txtRecoverCode6"
-            android:layout_width="72dp"
-            android:layout_height="48dp"
-            android:layout_marginLeft="8dp"
-            android:layout_marginStart="8dp"
-            android:ems="10"
-            android:hint="@string/reset_password_rescuecode_6"
-            android:inputType="phone"
-            android:maxLength="4"
-            android:nextFocusDown="@+id/btnRemoveAccountRemove"
-            app:layout_constraintStart_toEndOf="@+id/txtRecoverCode5"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-    </android.support.constraint.ConstraintLayout>
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/activity_rescuecode_enter.xml
+++ b/app/src/main/res/layout/activity_rescuecode_enter.xml
@@ -7,117 +7,28 @@
     android:id="@+id/rescueCodeEntryActivityView"
     tools:context="org.ea.sqrl.activites.create.RescueCodeEnterActivity">
 
-    <android.support.constraint.ConstraintLayout
-        android:id="@+id/inputRow1"
-        android:layout_width="wrap_content"
+    <TextView
+        android:id="@+id/rescueCodeEnterDescription"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="8dp"
-        android:layout_marginStart="8dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginStart="16dp"
         android:layout_marginTop="16dp"
-        android:layoutDirection="ltr"
-        android:focusable="false"
+        android:text="@string/rescue_code_enter_desc"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/textView18">
+        app:layout_constraintTop_toTopOf="parent" />
 
-        <EditText
-            android:id="@+id/txtRecoverCode1"
-            android:layout_width="72dp"
-            android:layout_height="48dp"
-            android:ems="10"
-            android:hint="@string/reset_password_rescuecode_1"
-            android:inputType="phone"
-            android:maxLength="4"
-            android:nextFocusDown="@+id/txtRecoverCode2"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-
-        <EditText
-            android:id="@+id/txtRecoverCode2"
-            android:layout_width="72dp"
-            android:layout_height="48dp"
-            android:layout_marginLeft="8dp"
-            android:layout_marginStart="8dp"
-            android:ems="10"
-            android:hint="@string/reset_password_rescuecode_2"
-            android:inputType="phone"
-            android:maxLength="4"
-            android:nextFocusDown="@+id/txtRecoverCode3"
-            app:layout_constraintStart_toEndOf="@+id/txtRecoverCode1"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-
-        <EditText
-            android:id="@+id/txtRecoverCode3"
-            android:layout_width="72dp"
-            android:layout_height="48dp"
-            android:layout_marginLeft="8dp"
-            android:layout_marginStart="8dp"
-            android:ems="10"
-            android:hint="@string/reset_password_rescuecode_3"
-            android:inputType="phone"
-            android:maxLength="4"
-            android:nextFocusDown="@+id/txtRecoverCode4"
-            app:layout_constraintStart_toEndOf="@+id/txtRecoverCode2"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-    </android.support.constraint.ConstraintLayout>
-
-    <android.support.constraint.ConstraintLayout
-        android:id="@+id/inputRow2"
-        android:layout_width="wrap_content"
+    <include layout="@layout/rescue_code_input"
+        android:id="@+id/rescueCodeInput"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="8dp"
-        android:layout_marginStart="8dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginStart="16dp"
         android:layout_marginTop="8dp"
-        android:focusable="false"
-        android:layoutDirection="ltr"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/inputRow1">
-
-        <EditText
-            android:id="@+id/txtRecoverCode4"
-            android:layout_width="72dp"
-            android:layout_height="48dp"
-            android:ems="10"
-            android:hint="@string/reset_password_rescuecode_4"
-            android:inputType="phone"
-            android:maxLength="4"
-            android:nextFocusDown="@+id/txtRecoverCode5"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-
-        <EditText
-            android:id="@+id/txtRecoverCode5"
-            android:layout_width="72dp"
-            android:layout_height="48dp"
-            android:layout_marginLeft="8dp"
-            android:layout_marginStart="8dp"
-            android:ems="10"
-            android:hint="@string/reset_password_rescuecode_5"
-            android:inputType="phone"
-            android:maxLength="4"
-            android:nextFocusDown="@+id/txtRecoverCode6"
-            app:layout_constraintStart_toEndOf="@+id/txtRecoverCode4"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-
-        <EditText
-            android:id="@+id/txtRecoverCode6"
-            android:layout_width="72dp"
-            android:layout_height="48dp"
-            android:layout_marginLeft="8dp"
-            android:layout_marginStart="8dp"
-            android:ems="10"
-            android:hint="@string/reset_password_rescuecode_6"
-            android:inputType="phone"
-            android:maxLength="4"
-            android:nextFocusDown="@+id/btnRescueCodeEnterNext"
-            app:layout_constraintStart_toEndOf="@+id/txtRecoverCode5"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-    </android.support.constraint.ConstraintLayout>
+        app:layout_constraintTop_toBottomOf="@+id/rescueCodeEnterDescription" />
 
     <Button
         android:id="@+id/btnRescueCodeEnterNext"
@@ -129,17 +40,6 @@
         android:text="@string/button_entropy_gather_next"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/inputRow2" />
+        app:layout_constraintTop_toBottomOf="@+id/rescueCodeInput" />
 
-    <TextView
-        android:id="@+id/textView18"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="16dp"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="16dp"
-        android:text="@string/rescue_code_enter_desc"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/activity_rescuecode_show.xml
+++ b/app/src/main/res/layout/activity_rescuecode_show.xml
@@ -7,145 +7,53 @@
     android:id="@+id/rescueCodeShowActivityView"
     tools:context="org.ea.sqrl.activites.create.RescueCodeShowActivity">
 
-    <android.support.constraint.ConstraintLayout
-        android:id="@+id/inputRow1"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="8dp"
-        android:layout_marginStart="8dp"
+    <TextView
+        android:id="@+id/txtRescueCodeShowDescription"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginStart="16dp"
         android:layout_marginTop="16dp"
-        android:focusable="false"
-        android:layoutDirection="ltr"
+        android:layout_marginEnd="16dp"
+        android:text="@string/rescuecode_show_desc"
+        app:layout_constraintBottom_toTopOf="@+id/rescueCodeInput"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/textView17">
+        app:layout_constraintTop_toTopOf="parent" />
 
-        <TextView
-            android:id="@+id/txtRecoverCode1"
-            android:layout_width="72dp"
-            android:layout_height="wrap_content"
-            android:ems="10"
-            android:nextFocusDown="@+id/txtRecoverCode2"
-            android:textAlignment="center"
-            android:textAppearance="@style/TextAppearance.AppCompat.Large"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-
-        <TextView
-            android:id="@+id/txtRecoverCode2"
-            android:layout_width="72dp"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="8dp"
-            android:layout_marginStart="8dp"
-            android:ems="10"
-            android:nextFocusDown="@+id/txtRecoverCode3"
-            android:textAlignment="center"
-            android:textAppearance="@style/TextAppearance.AppCompat.Large"
-            app:layout_constraintStart_toEndOf="@+id/txtRecoverCode1"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-
-        <TextView
-            android:id="@+id/txtRecoverCode3"
-            android:layout_width="72dp"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="8dp"
-            android:layout_marginStart="8dp"
-            android:ems="10"
-            android:nextFocusDown="@+id/txtRecoverCode4"
-            android:textAlignment="center"
-            android:textAppearance="@style/TextAppearance.AppCompat.Large"
-            app:layout_constraintStart_toEndOf="@+id/txtRecoverCode2"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-    </android.support.constraint.ConstraintLayout>
-
-    <android.support.constraint.ConstraintLayout
-        android:id="@+id/inputRow2"
-        android:layout_width="wrap_content"
+    <include
+        android:id="@+id/rescueCodeInput"
+        layout="@layout/rescue_code_input"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="8dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:focusable="false"
-        android:layoutDirection="ltr"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="8dp"
+        app:layout_constraintBottom_toTopOf="@+id/btnPrintRescueCode"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/inputRow1">
-
-        <TextView
-            android:id="@+id/txtRecoverCode4"
-            android:layout_width="72dp"
-            android:layout_height="wrap_content"
-            android:ems="10"
-            android:nextFocusDown="@+id/txtRecoverCode5"
-            android:textAlignment="center"
-            android:textAppearance="@style/TextAppearance.AppCompat.Large"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-
-        <TextView
-            android:id="@+id/txtRecoverCode5"
-            android:layout_width="72dp"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="8dp"
-            android:layout_marginStart="8dp"
-            android:ems="10"
-            android:nextFocusDown="@+id/txtRecoverCode6"
-            android:textAlignment="center"
-            android:textAppearance="@style/TextAppearance.AppCompat.Large"
-            app:layout_constraintStart_toEndOf="@+id/txtRecoverCode4"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-
-        <TextView
-            android:id="@+id/txtRecoverCode6"
-            android:layout_width="72dp"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="8dp"
-            android:layout_marginStart="8dp"
-            android:ems="10"
-            android:nextFocusDown="@+id/txtResetPasswordNewPassword"
-            android:textAlignment="center"
-            android:textAppearance="@style/TextAppearance.AppCompat.Large"
-            app:layout_constraintStart_toEndOf="@+id/txtRecoverCode5"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-    </android.support.constraint.ConstraintLayout>
+        app:layout_constraintStart_toStartOf="parent" />
 
     <Button
         android:id="@+id/btnPrintRescueCode"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="16dp"
         android:layout_marginStart="16dp"
-        android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="8dp"
         android:text="@string/button_print_rescue_code"
+        app:layout_constraintBottom_toTopOf="@+id/btnRescueCodeShowNext"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/inputRow2" />
+        app:layout_constraintStart_toStartOf="parent" />
 
     <Button
         android:id="@+id/btnRescueCodeShowNext"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="16dp"
         android:layout_marginStart="16dp"
-        android:layout_marginTop="8dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="16dp"
         android:text="@string/button_entropy_gather_next"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/btnPrintRescueCode" />
+        app:layout_constraintStart_toStartOf="parent" />
 
-    <TextView
-        android:id="@+id/textView17"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="16dp"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="16dp"
-        android:text="@string/rescuecode_show_desc"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/activity_reset_password.xml
+++ b/app/src/main/res/layout/activity_reset_password.xml
@@ -18,117 +18,16 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <android.support.constraint.ConstraintLayout
-        android:id="@+id/inputRow2"
-        android:layout_width="wrap_content"
+    <include layout="@layout/rescue_code_input"
+        android:id="@+id/rescueCodeInput"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="8dp"
-        android:layout_marginStart="8dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginStart="16dp"
         android:layout_marginTop="8dp"
-        android:focusable="false"
-        android:layoutDirection="ltr"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/inputRow1">
-
-        <EditText
-            android:id="@+id/txtRecoverCode4"
-            android:layout_width="72dp"
-            android:layout_height="48dp"
-            android:ems="10"
-            android:hint="@string/reset_password_rescuecode_4"
-            android:inputType="phone"
-            android:maxLength="4"
-            android:nextFocusDown="@+id/txtRecoverCode5"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-
-        <EditText
-            android:id="@+id/txtRecoverCode5"
-            android:layout_width="72dp"
-            android:layout_height="48dp"
-            android:layout_marginLeft="8dp"
-            android:layout_marginStart="8dp"
-            android:ems="10"
-            android:hint="@string/reset_password_rescuecode_5"
-            android:inputType="phone"
-            android:maxLength="4"
-            android:nextFocusDown="@+id/txtRecoverCode6"
-            app:layout_constraintStart_toEndOf="@+id/txtRecoverCode4"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-
-        <EditText
-            android:id="@+id/txtRecoverCode6"
-            android:layout_width="72dp"
-            android:layout_height="48dp"
-            android:layout_marginLeft="8dp"
-            android:layout_marginStart="8dp"
-            android:ems="10"
-            android:hint="@string/reset_password_rescuecode_6"
-            android:inputType="phone"
-            android:maxLength="4"
-            android:nextFocusDown="@+id/txtResetPasswordNewPassword"
-            app:layout_constraintStart_toEndOf="@+id/txtRecoverCode5"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-    </android.support.constraint.ConstraintLayout>
-
-    <android.support.constraint.ConstraintLayout
-        android:id="@+id/inputRow1"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="8dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="16dp"
-        android:focusable="false"
-        android:layoutDirection="ltr"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/txtResetPasswordDescription">
-
-        <EditText
-            android:id="@+id/txtRecoverCode1"
-            android:layout_width="72dp"
-            android:layout_height="48dp"
-            android:ems="10"
-            android:hint="@string/reset_password_rescuecode_1"
-            android:inputType="phone"
-            android:maxLength="4"
-            android:nextFocusDown="@+id/txtRecoverCode2"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-
-        <EditText
-            android:id="@+id/txtRecoverCode2"
-            android:layout_width="72dp"
-            android:layout_height="48dp"
-            android:layout_marginLeft="8dp"
-            android:layout_marginStart="8dp"
-            android:ems="10"
-            android:hint="@string/reset_password_rescuecode_2"
-            android:inputType="phone"
-            android:maxLength="4"
-            android:nextFocusDown="@+id/txtRecoverCode3"
-            app:layout_constraintStart_toEndOf="@+id/txtRecoverCode1"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-
-        <EditText
-            android:id="@+id/txtRecoverCode3"
-            android:layout_width="72dp"
-            android:layout_height="48dp"
-            android:layout_marginLeft="8dp"
-            android:layout_marginStart="8dp"
-            android:ems="10"
-            android:hint="@string/reset_password_rescuecode_3"
-            android:inputType="phone"
-            android:maxLength="4"
-            android:nextFocusDown="@+id/txtRecoverCode4"
-            app:layout_constraintStart_toEndOf="@+id/txtRecoverCode2"
-            tools:layout_conversion_absoluteHeight="46dp"
-            tools:layout_conversion_absoluteWidth="327dp" />
-    </android.support.constraint.ConstraintLayout>
+        app:layout_constraintTop_toBottomOf="@+id/txtResetPasswordDescription" />
 
 
     <android.support.design.widget.TextInputLayout
@@ -142,7 +41,7 @@
         app:passwordToggleEnabled="true"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/inputRow2">
+        app:layout_constraintTop_toBottomOf="@+id/rescueCodeInput">
 
         <android.support.design.widget.TextInputEditText
             android:id="@+id/txtResetPasswordNewPassword"

--- a/app/src/main/res/layout/rescue_code_input.xml
+++ b/app/src/main/res/layout/rescue_code_input.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/rescueCodeInputContainer"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <android.support.constraint.ConstraintLayout
+        android:id="@+id/rescueCodeInputRow1"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="16dp"
+        android:layoutDirection="ltr"
+        android:focusable="false"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <EditText
+            android:id="@+id/txtRecoverCode1"
+            android:layout_width="72dp"
+            android:layout_height="48dp"
+            android:ems="10"
+            android:hint="@string/reset_password_rescuecode_1"
+            android:inputType="phone"
+            android:maxLength="4"
+            android:nextFocusDown="@+id/txtRecoverCode2"
+            tools:layout_conversion_absoluteHeight="46dp"
+            tools:layout_conversion_absoluteWidth="327dp"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+
+        <EditText
+            android:id="@+id/txtRecoverCode2"
+            android:layout_width="72dp"
+            android:layout_height="48dp"
+            android:layout_marginLeft="8dp"
+            android:layout_marginStart="8dp"
+            android:ems="10"
+            android:hint="@string/reset_password_rescuecode_2"
+            android:inputType="phone"
+            android:maxLength="4"
+            android:nextFocusDown="@+id/txtRecoverCode3"
+            tools:layout_conversion_absoluteHeight="46dp"
+            tools:layout_conversion_absoluteWidth="327dp"
+            app:layout_constraintStart_toEndOf="@+id/txtRecoverCode1"
+            app:layout_constraintTop_toTopOf="@+id/txtRecoverCode1"/>
+
+        <EditText
+            android:id="@+id/txtRecoverCode3"
+            android:layout_width="72dp"
+            android:layout_height="48dp"
+            android:layout_marginLeft="8dp"
+            android:layout_marginStart="8dp"
+            android:ems="10"
+            android:hint="@string/reset_password_rescuecode_3"
+            android:inputType="phone"
+            android:maxLength="4"
+            android:nextFocusDown="@+id/txtRecoverCode4"
+            tools:layout_conversion_absoluteHeight="46dp"
+            tools:layout_conversion_absoluteWidth="327dp"
+            app:layout_constraintStart_toEndOf="@+id/txtRecoverCode2"
+            app:layout_constraintTop_toTopOf="@+id/txtRecoverCode2"/>
+    </android.support.constraint.ConstraintLayout>
+
+    <android.support.constraint.ConstraintLayout
+        android:id="@+id/rescueCodeInputRow2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:focusable="false"
+        android:layoutDirection="ltr"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/rescueCodeInputRow1">
+
+        <EditText
+            android:id="@+id/txtRecoverCode4"
+            android:layout_width="72dp"
+            android:layout_height="48dp"
+            android:ems="10"
+            android:hint="@string/reset_password_rescuecode_4"
+            android:inputType="phone"
+            android:maxLength="4"
+            android:nextFocusDown="@+id/txtRecoverCode5"
+            tools:layout_conversion_absoluteHeight="46dp"
+            tools:layout_conversion_absoluteWidth="327dp"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"/>
+
+        <EditText
+            android:id="@+id/txtRecoverCode5"
+            android:layout_width="72dp"
+            android:layout_height="48dp"
+            android:layout_marginLeft="8dp"
+            android:layout_marginStart="8dp"
+            android:ems="10"
+            android:hint="@string/reset_password_rescuecode_5"
+            android:inputType="phone"
+            android:maxLength="4"
+            android:nextFocusDown="@+id/txtRecoverCode6"
+            tools:layout_conversion_absoluteHeight="46dp"
+            tools:layout_conversion_absoluteWidth="327dp"
+            app:layout_constraintStart_toEndOf="@+id/txtRecoverCode4"
+            app:layout_constraintTop_toTopOf="@+id/txtRecoverCode4" />
+
+        <EditText
+            android:id="@+id/txtRecoverCode6"
+            android:layout_width="72dp"
+            android:layout_height="48dp"
+            android:layout_marginLeft="8dp"
+            android:layout_marginStart="8dp"
+            android:ems="10"
+            android:hint="@string/reset_password_rescuecode_6"
+            android:inputType="phone"
+            android:maxLength="4"
+            tools:layout_conversion_absoluteHeight="46dp"
+            tools:layout_conversion_absoluteWidth="327dp"
+            app:layout_constraintStart_toEndOf="@+id/txtRecoverCode5"
+            app:layout_constraintTop_toTopOf="@+id/txtRecoverCode5" />
+
+    </android.support.constraint.ConstraintLayout>
+
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -239,4 +239,5 @@
 <string name="img_password_contains_digits">Indicates whether the password contains digits</string>
 <string name="img_password_contains_symbols">Indicates whether the password contains symbols</string>
 <string name="short_password_warning">You are using a very short password. This is highly insecure and should absolutely be avoided!</string>
+<string name="rescue_code_incorrect">Incorrect</string>
 </resources>


### PR DESCRIPTION
Issue #298 .

Description:
Removed duplicate layout code and replaced it with only one import file: *rescue_code_input.xml*
Also added a helper class for dealing with input verification. The code of the affected activities was also refactored to use the this new helper class. All the logic is now in one place.

The following activities (layout and code) were affected:
```
activity_enable_account.xml
activity_rekey_verify.xml
activity_remove_account.xml
activity_rescuecode_show.xml
activity_rescuecode_enter.xml
activity_reset_password.xml
```

Changes/improvements:
- Removed duplicate layout code
- Removed duplicate verification code
- Removed error popups in favour of on-the-fly form input checks. Also, the "next"-button is now enabled/disabled on the fly for most of the activities.
- Focus now jumps to the next field automatically
- Resolved a display bug in activity_rescuecode_show.xml which would let the buttons move off screen if the description text was long (like with the German translation)

I have also found some other bugs and glitches along the way which I will address separately.

Looking forward to your review, @kalaspuffar and @sengsational !
