### PR TITLE
Remove quickpass notification

### DIFF
--- a/app/src/main/java/org/ea/sqrl/activites/account/DisableAccountActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/account/DisableAccountActivity.java
@@ -31,7 +31,7 @@ public class DisableAccountActivity extends BaseActivity {
             new Thread(() -> {
                 boolean decryptionOk = storage.decryptIdentityKey(txtDisablePassword.getText().toString(), entropyHarvester, false);
                 if(decryptionOk) {
-                    showClearNotification();
+                    clearQuickPassDelayed();
                 } else {
                     showErrorMessage(R.string.decrypt_identity_fail);
                     storage.clearQuickPass();

--- a/app/src/main/java/org/ea/sqrl/activites/base/BaseActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/base/BaseActivity.java
@@ -396,8 +396,6 @@ public class BaseActivity extends AppCompatActivity {
         if (mNotificationManager != null) {
             mNotificationManager.notify(NOTIFICATION_IDENTITY_UNLOCKED, mBuilder.build());
         }
-
-        clearQuickPassDelayed();
     }
 
     public void clearQuickPassDelayed() {

--- a/app/src/main/java/org/ea/sqrl/activites/base/BaseActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/base/BaseActivity.java
@@ -361,7 +361,7 @@ public class BaseActivity extends AppCompatActivity {
             notificationChannel.enableLights(false);
             notificationChannel.setSound(null, null);
 
-            if(notificationManager != null) {
+            if (notificationManager != null) {
                 notificationManager.createNotificationChannel(notificationChannel);
             }
         }
@@ -393,10 +393,14 @@ public class BaseActivity extends AppCompatActivity {
         NotificationManager mNotificationManager =
                 (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
 
-        if(mNotificationManager != null) {
+        if (mNotificationManager != null) {
             mNotificationManager.notify(NOTIFICATION_IDENTITY_UNLOCKED, mBuilder.build());
         }
 
+        clearQuickPassDelayed();
+    }
+
+    public void clearQuickPassDelayed() {
         long delayMillis = SQRLStorage.getInstance(BaseActivity.this.getApplicationContext()).getIdleTimeout() * 60000;
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {

--- a/app/src/main/java/org/ea/sqrl/activites/base/LoginBaseActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/base/LoginBaseActivity.java
@@ -235,7 +235,7 @@ public class LoginBaseActivity extends BaseActivity implements AdapterView.OnIte
                 storage.clearQuickPass();
                 return;
             }
-            showClearNotification();
+            clearQuickPassDelayed();
 
             handler.post(() -> txtLoginPassword.setText(""));
 

--- a/app/src/main/java/org/ea/sqrl/activites/identity/ChangePasswordActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/identity/ChangePasswordActivity.java
@@ -58,7 +58,7 @@ public class ChangePasswordActivity extends BaseActivity {
 
                     return;
                 }
-                showClearNotification();
+                clearQuickPassDelayed();
 
                 boolean encryptStatus = storage.encryptIdentityKey(txtNewPassword.getText().toString(), entropyHarvester);
                 if (!encryptStatus) {


### PR DESCRIPTION
Issue #302.

Description:
Quickpass notification is shown in the notification bar and enables the removal of quickpass from the phone to increase security. This feature should be removed because it's confusing to users.

Changes:
Starting the background job for the delayed clearing of the QuickPass was decoupled from showing the notification. Finally, all calls to `showClearNotification()` were replaced with `clearQuickPassDelayed()`.

`showClearNotification()` was left in, maybe we'll decide to offer the functionality to power users later. 
