### PR TITLE
Fix: Lastpass is triggered by settings window

### DIFF
--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -18,6 +18,7 @@
         android:inputType="number"
         android:nextFocusDown="@+id/txtSettingsPasswordVerifyInSeconds"
         android:hint="@string/settings_hint_length"
+        android:importantForAutofill="no"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/textView10" />
@@ -33,6 +34,7 @@
         android:inputType="number"
         android:nextFocusDown="@+id/txtSettingsIdleTimeout"
         android:hint="@string/settings_password_verify"
+        android:importantForAutofill="no"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/textView11"
@@ -49,6 +51,7 @@
         android:inputType="number"
         android:nextFocusDown="@+id/cbSettingsSQRLOnly"
         android:hint="@string/settings_idle_timeout"
+        android:importantForAutofill="no"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/textView12" />


### PR DESCRIPTION
Issue #221.

Description:
Lastpass was triggered by the following InputText field in the settings activity:
```
<EditText
        android:id="@+id/txtSettingsPasswordVerifyInSeconds"
        ...
```

Changes:
Added `android:importantForAutofill="no"` to the TextInput fields in the settings activity.

This just works on API 26+ but it sucessfully prevents Lastpass from popping up for me.
