### PR TITLE
Language change fix

### DIFF
--- a/app/src/main/java/org/ea/sqrl/activites/IntroductionActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/IntroductionActivity.java
@@ -35,8 +35,6 @@ public class IntroductionActivity extends AppCompatActivity {
         setContentView(R.layout.activity_introduction);
         AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_AUTO);
 
-        Utils.setLanguage(this);
-
         final SectionsPagerAdapter mSectionsPagerAdapter = new SectionsPagerAdapter(getSupportFragmentManager());
 
         // Set up the ViewPager with the sections adapter.
@@ -55,6 +53,12 @@ public class IntroductionActivity extends AppCompatActivity {
         btnClose.setOnClickListener(v -> new Thread(() -> {
             IntroductionActivity.this.finish();
         }).start());
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        Utils.setLanguage(this);
     }
 
     /**

--- a/app/src/main/java/org/ea/sqrl/activites/IntroductionActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/IntroductionActivity.java
@@ -1,8 +1,6 @@
 package org.ea.sqrl.activites;
 
-import android.content.res.Configuration;
 import android.support.design.widget.TabLayout;
-import android.support.v7.app.AppCompatActivity;
 
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
@@ -19,8 +17,8 @@ import android.widget.Button;
 import android.widget.TextView;
 
 import org.ea.sqrl.R;
+import org.ea.sqrl.activites.base.CommonBaseActivity;
 import org.ea.sqrl.processors.SQRLStorage;
-import org.ea.sqrl.utils.Utils;
 
 /**
  * This activity is used to inform the user about the different features, techniques use cases
@@ -29,7 +27,7 @@ import org.ea.sqrl.utils.Utils;
  *
  * @author Daniel Persson
  */
-public class IntroductionActivity extends AppCompatActivity {
+public class IntroductionActivity extends CommonBaseActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -54,13 +52,6 @@ public class IntroductionActivity extends AppCompatActivity {
         btnClose.setOnClickListener(v -> new Thread(() -> {
             IntroductionActivity.this.finish();
         }).start());
-    }
-
-    @Override
-    protected void onResume() {
-        super.onResume();
-        Utils.setLanguage(this);
-        Utils.reloadActivityTitle(this);
     }
 
     /**

--- a/app/src/main/java/org/ea/sqrl/activites/IntroductionActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/IntroductionActivity.java
@@ -1,5 +1,6 @@
 package org.ea.sqrl.activites;
 
+import android.content.res.Configuration;
 import android.support.design.widget.TabLayout;
 import android.support.v7.app.AppCompatActivity;
 
@@ -59,6 +60,7 @@ public class IntroductionActivity extends AppCompatActivity {
     protected void onResume() {
         super.onResume();
         Utils.setLanguage(this);
+        Utils.reloadActivityTitle(this);
     }
 
     /**

--- a/app/src/main/java/org/ea/sqrl/activites/LanguageActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/LanguageActivity.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
-import android.support.v7.app.AppCompatActivity;
 import android.support.v7.app.AppCompatDelegate;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
@@ -15,6 +14,7 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import org.ea.sqrl.R;
+import org.ea.sqrl.activites.base.CommonBaseActivity;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,7 +23,7 @@ import java.util.List;
  *
  * @author Daniel Persson
  */
-public class LanguageActivity extends AppCompatActivity {
+public class LanguageActivity extends CommonBaseActivity {
     private static final String TAG = "LanguageActivity";
 
     @Override

--- a/app/src/main/java/org/ea/sqrl/activites/base/BaseActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/base/BaseActivity.java
@@ -36,6 +36,8 @@ import android.widget.PopupWindow;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
+import com.journeyapps.barcodescanner.Util;
+
 import org.ea.sqrl.BuildConfig;
 import org.ea.sqrl.R;
 import org.ea.sqrl.activites.LanguageActivity;
@@ -79,6 +81,7 @@ public class BaseActivity extends AppCompatActivity {
     protected EntropyHarvester entropyHarvester;
 
     private boolean openedLanguageDialog = false;
+    private String language;
 
     public BaseActivity() {
         mDbHelper = new IdentityDBHelper(this);
@@ -92,16 +95,31 @@ public class BaseActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        Utils.setLanguage(this);
+        Utils.reloadActivityTitle(this);
+        language = Utils.getLanguage(this);
     }
 
     @Override
     protected void onResume() {
         super.onResume();
-        Utils.setLanguage(this);
-        if(openedLanguageDialog) {
+
+        if(!language.equals(Utils.getLanguage(this))) {
             this.recreate();
-            openedLanguageDialog = false;
+            language = Utils.getLanguage(this);
         }
+//        if(openedLanguageDialog) {
+//            this.recreate();
+//            openedLanguageDialog = false;
+//        }
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+        Utils.setLanguage(this);
+        Utils.reloadActivityTitle(this);
     }
 
     @Override

--- a/app/src/main/java/org/ea/sqrl/activites/base/BaseActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/base/BaseActivity.java
@@ -23,7 +23,6 @@ import android.os.Looper;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.content.ContextCompat;
-import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.Gravity;
 import android.view.LayoutInflater;
@@ -35,8 +34,6 @@ import android.widget.Button;
 import android.widget.PopupWindow;
 import android.widget.ProgressBar;
 import android.widget.TextView;
-
-import com.journeyapps.barcodescanner.Util;
 
 import org.ea.sqrl.BuildConfig;
 import org.ea.sqrl.R;
@@ -50,16 +47,15 @@ import org.ea.sqrl.processors.ProgressionUpdater;
 import org.ea.sqrl.processors.SQRLStorage;
 import org.ea.sqrl.services.ClearIdentityReceiver;
 import org.ea.sqrl.services.ClearIdentityService;
-import org.ea.sqrl.utils.Utils;
 
 /**
- * This base activity is inherited by all other activities. We place logic used for menus,
+ * This base activity is inherited by all other activities that need logic used for menus,
  * background processes and other things that are untied to the current context of the application.
  *
  * @author Daniel Persson
  */
 @SuppressLint("Registered")
-public class BaseActivity extends AppCompatActivity {
+public class BaseActivity extends CommonBaseActivity {
     private static final String TAG = "BaseActivity";
     protected static final String CURRENT_ID = "current_id";
     protected static final String APPS_PREFERENCES = "org.ea.sqrl.preferences";
@@ -80,9 +76,6 @@ public class BaseActivity extends AppCompatActivity {
     protected final IdentityDBHelper mDbHelper;
     protected EntropyHarvester entropyHarvester;
 
-    private boolean openedLanguageDialog = false;
-    private String language;
-
     public BaseActivity() {
         mDbHelper = new IdentityDBHelper(this);
         try {
@@ -93,34 +86,7 @@ public class BaseActivity extends AppCompatActivity {
     }
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-
-        Utils.setLanguage(this);
-        Utils.reloadActivityTitle(this);
-        language = Utils.getLanguage(this);
-    }
-
-    @Override
-    protected void onResume() {
-        super.onResume();
-
-        if(!language.equals(Utils.getLanguage(this))) {
-            this.recreate();
-            language = Utils.getLanguage(this);
-        }
-//        if(openedLanguageDialog) {
-//            this.recreate();
-//            openedLanguageDialog = false;
-//        }
-    }
-
-    @Override
-    public void onConfigurationChanged(Configuration newConfig) {
-        super.onConfigurationChanged(newConfig);
-        Utils.setLanguage(this);
-        Utils.reloadActivityTitle(this);
-    }
+    protected void onCreate(Bundle savedInstanceState) { super.onCreate(savedInstanceState); }
 
     @Override
     protected void onSaveInstanceState(Bundle outState) {
@@ -178,7 +144,6 @@ public class BaseActivity extends AppCompatActivity {
                 startActivity(new Intent(this, IntroductionActivity.class));
                 return true;
             case R.id.action_language:
-                openedLanguageDialog = true;
                 startActivity(new Intent(this, LanguageActivity.class));
                 return true;
             case R.id.action_advanced_options:

--- a/app/src/main/java/org/ea/sqrl/activites/base/CommonBaseActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/base/CommonBaseActivity.java
@@ -1,0 +1,49 @@
+package org.ea.sqrl.activites.base;
+
+import android.content.res.Configuration;
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+
+import org.ea.sqrl.utils.Utils;
+
+/**
+ * This activity is inherited by all other activities and provides common logic
+ * such as language support.
+ *
+ * @author Alexander Hauser
+ */
+public class CommonBaseActivity extends AppCompatActivity {
+    private static final String TAG = "CommonBaseActivity";
+    protected  String mCurrentLanguage;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        Utils.setLanguage(this);
+        Utils.reloadActivityTitle(this);
+
+        mCurrentLanguage = Utils.getLanguage(this);
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        recreateIfLanguageChanged();
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+        recreateIfLanguageChanged();
+    }
+
+    protected void recreateIfLanguageChanged() {
+        String language = Utils.getLanguage(this);
+
+        if (!mCurrentLanguage.equals(language)) {
+            mCurrentLanguage = language;
+            this.recreate();
+        }
+    }
+}

--- a/app/src/main/java/org/ea/sqrl/activites/create/CreateIdentityActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/create/CreateIdentityActivity.java
@@ -2,15 +2,14 @@ package org.ea.sqrl.activites.create;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
 import android.support.v7.app.AppCompatDelegate;
 import android.text.method.LinkMovementMethod;
 import android.widget.Button;
 import android.widget.TextView;
 
 import org.ea.sqrl.R;
+import org.ea.sqrl.activites.base.CommonBaseActivity;
 import org.ea.sqrl.processors.SQRLStorage;
-import org.ea.sqrl.utils.Utils;
 
 /**
  * Start activity should be a base for the user so we bring them into the application and they know
@@ -19,7 +18,7 @@ import org.ea.sqrl.utils.Utils;
  *
  * @author Daniel Persson
  */
-public class CreateIdentityActivity extends AppCompatActivity {
+public class CreateIdentityActivity extends CommonBaseActivity {
     private static final String TAG = "CreateIdentityActivity";
 
     @Override
@@ -40,12 +39,5 @@ public class CreateIdentityActivity extends AppCompatActivity {
                     startActivity(new Intent(this, EntropyGatherActivity.class));
                 }
         );
-    }
-
-    @Override
-    protected void onResume() {
-        super.onResume();
-        Utils.setLanguage(this);
-        Utils.reloadActivityTitle(this);
     }
 }

--- a/app/src/main/java/org/ea/sqrl/activites/create/CreateIdentityActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/create/CreateIdentityActivity.java
@@ -46,5 +46,6 @@ public class CreateIdentityActivity extends AppCompatActivity {
     protected void onResume() {
         super.onResume();
         Utils.setLanguage(this);
+        Utils.reloadActivityTitle(this);
     }
 }

--- a/app/src/main/java/org/ea/sqrl/activites/create/CreateIdentityActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/create/CreateIdentityActivity.java
@@ -28,8 +28,6 @@ public class CreateIdentityActivity extends AppCompatActivity {
         setContentView(R.layout.activity_create_identity);
         AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_AUTO);
 
-        Utils.setLanguage(this);
-
         SQRLStorage.getInstance(CreateIdentityActivity.this.getApplicationContext()).cleanIdentity();
 
         final TextView txtCreateIdentityMessage = findViewById(R.id.txtCreateIdentityMessage);
@@ -42,5 +40,11 @@ public class CreateIdentityActivity extends AppCompatActivity {
                     startActivity(new Intent(this, EntropyGatherActivity.class));
                 }
         );
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        Utils.setLanguage(this);
     }
 }

--- a/app/src/main/java/org/ea/sqrl/activites/create/EntropyGatherActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/create/EntropyGatherActivity.java
@@ -43,9 +43,13 @@ public class EntropyGatherActivity extends AppCompatActivity {
         setContentView(R.layout.activity_entropy_gather);
         AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_AUTO);
 
-        Utils.setLanguage(this);
-
         showPhoneStatePermission();
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        Utils.setLanguage(this);
     }
 
     private void initCameraUsage() {

--- a/app/src/main/java/org/ea/sqrl/activites/create/EntropyGatherActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/create/EntropyGatherActivity.java
@@ -50,6 +50,7 @@ public class EntropyGatherActivity extends AppCompatActivity {
     protected void onResume() {
         super.onResume();
         Utils.setLanguage(this);
+        Utils.reloadActivityTitle(this);
     }
 
     private void initCameraUsage() {

--- a/app/src/main/java/org/ea/sqrl/activites/create/EntropyGatherActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/create/EntropyGatherActivity.java
@@ -8,7 +8,6 @@ import android.content.pm.PackageManager;
 import android.hardware.Camera;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
-import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatDelegate;
 import android.util.Log;
@@ -19,8 +18,8 @@ import android.widget.FrameLayout;
 import android.widget.ProgressBar;
 
 import org.ea.sqrl.R;
+import org.ea.sqrl.activites.base.CommonBaseActivity;
 import org.ea.sqrl.processors.EntropyHarvester;
-import org.ea.sqrl.utils.Utils;
 
 import java.io.IOException;
 
@@ -28,7 +27,7 @@ import java.io.IOException;
  *
  * @author Daniel Persson
  */
-public class EntropyGatherActivity extends AppCompatActivity {
+public class EntropyGatherActivity extends CommonBaseActivity {
     private static final String TAG = "EntropyGatherActivity";
 
     private final int REQUEST_PERMISSION_CAMERA = 1;
@@ -44,13 +43,6 @@ public class EntropyGatherActivity extends AppCompatActivity {
         AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_AUTO);
 
         showPhoneStatePermission();
-    }
-
-    @Override
-    protected void onResume() {
-        super.onResume();
-        Utils.setLanguage(this);
-        Utils.reloadActivityTitle(this);
     }
 
     private void initCameraUsage() {

--- a/app/src/main/java/org/ea/sqrl/activites/create/RekeyIdentityActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/create/RekeyIdentityActivity.java
@@ -43,5 +43,6 @@ public class RekeyIdentityActivity extends AppCompatActivity {
     protected void onResume() {
         super.onResume();
         Utils.setLanguage(this);
+        Utils.reloadActivityTitle(this);
     }
 }

--- a/app/src/main/java/org/ea/sqrl/activites/create/RekeyIdentityActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/create/RekeyIdentityActivity.java
@@ -25,8 +25,6 @@ public class RekeyIdentityActivity extends AppCompatActivity {
         setContentView(R.layout.activity_rekey_identity);
         AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_AUTO);
 
-        Utils.setLanguage(this);
-
         SQRLStorage.getInstance(RekeyIdentityActivity.this.getApplicationContext()).clear();
 
         final TextView txtRekeyIdentityMessage = findViewById(R.id.txtRekeyIdentityMessage);
@@ -39,5 +37,11 @@ public class RekeyIdentityActivity extends AppCompatActivity {
                     startActivity(new Intent(this, RekeyVerifyActivity.class));
                 }
         );
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        Utils.setLanguage(this);
     }
 }

--- a/app/src/main/java/org/ea/sqrl/activites/create/RekeyIdentityActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/create/RekeyIdentityActivity.java
@@ -2,21 +2,20 @@ package org.ea.sqrl.activites.create;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
 import android.support.v7.app.AppCompatDelegate;
 import android.text.method.LinkMovementMethod;
 import android.widget.Button;
 import android.widget.TextView;
 
 import org.ea.sqrl.R;
+import org.ea.sqrl.activites.base.CommonBaseActivity;
 import org.ea.sqrl.processors.SQRLStorage;
-import org.ea.sqrl.utils.Utils;
 
 /**
  *
  * @author Daniel Persson
  */
-public class RekeyIdentityActivity extends AppCompatActivity {
+public class RekeyIdentityActivity extends CommonBaseActivity {
     private static final String TAG = "RekeyIdentityActivity";
 
     @Override
@@ -37,12 +36,5 @@ public class RekeyIdentityActivity extends AppCompatActivity {
                     startActivity(new Intent(this, RekeyVerifyActivity.class));
                 }
         );
-    }
-
-    @Override
-    protected void onResume() {
-        super.onResume();
-        Utils.setLanguage(this);
-        Utils.reloadActivityTitle(this);
     }
 }

--- a/app/src/main/java/org/ea/sqrl/activites/create/RescueCodeEnterActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/create/RescueCodeEnterActivity.java
@@ -24,8 +24,6 @@ public class RescueCodeEnterActivity extends AppCompatActivity {
         setContentView(R.layout.activity_rescuecode_enter);
         AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_AUTO);
 
-        Utils.setLanguage(this);
-
         ViewGroup rootLayout = findViewById(R.id.rescueCodeEntryActivityView);
         Button btnRescueCodeEnterNext = findViewById(R.id.btnRescueCodeEnterNext);
 
@@ -43,5 +41,11 @@ public class RescueCodeEnterActivity extends AppCompatActivity {
 
         boolean runningTest = getIntent().getBooleanExtra("RUNNING_TEST", false);
         if(runningTest) return;
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        Utils.setLanguage(this);
     }
 }

--- a/app/src/main/java/org/ea/sqrl/activites/create/RescueCodeEnterActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/create/RescueCodeEnterActivity.java
@@ -2,20 +2,19 @@ package org.ea.sqrl.activites.create;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
 import android.support.v7.app.AppCompatDelegate;
 import android.view.ViewGroup;
 import android.widget.Button;
 
 import org.ea.sqrl.R;
+import org.ea.sqrl.activites.base.CommonBaseActivity;
 import org.ea.sqrl.utils.RescueCodeInputHelper;
-import org.ea.sqrl.utils.Utils;
 
 /**
  *
  * @author Daniel Persson
  */
-public class RescueCodeEnterActivity extends AppCompatActivity {
+public class RescueCodeEnterActivity extends CommonBaseActivity {
     private static final String TAG = "RescueCodeEnterActivity";
 
     @Override
@@ -41,12 +40,5 @@ public class RescueCodeEnterActivity extends AppCompatActivity {
 
         boolean runningTest = getIntent().getBooleanExtra("RUNNING_TEST", false);
         if(runningTest) return;
-    }
-
-    @Override
-    protected void onResume() {
-        super.onResume();
-        Utils.setLanguage(this);
-        Utils.reloadActivityTitle(this);
     }
 }

--- a/app/src/main/java/org/ea/sqrl/activites/create/RescueCodeEnterActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/create/RescueCodeEnterActivity.java
@@ -47,5 +47,6 @@ public class RescueCodeEnterActivity extends AppCompatActivity {
     protected void onResume() {
         super.onResume();
         Utils.setLanguage(this);
+        Utils.reloadActivityTitle(this);
     }
 }

--- a/app/src/main/java/org/ea/sqrl/activites/create/RescueCodeShowActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/create/RescueCodeShowActivity.java
@@ -8,7 +8,6 @@ import android.os.Bundle;
 import android.print.PrintAttributes;
 import android.print.PrintManager;
 
-import android.support.v7.app.AppCompatActivity;
 import android.support.v7.app.AppCompatDelegate;
 import android.text.method.LinkMovementMethod;
 import android.util.Log;
@@ -17,11 +16,11 @@ import android.widget.Button;
 import android.widget.TextView;
 
 import org.ea.sqrl.R;
+import org.ea.sqrl.activites.base.CommonBaseActivity;
 import org.ea.sqrl.processors.EntropyHarvester;
 import org.ea.sqrl.processors.SQRLStorage;
 import org.ea.sqrl.services.RescueCodePrintDocumentAdapter;
 import org.ea.sqrl.utils.RescueCodeInputHelper;
-import org.ea.sqrl.utils.Utils;
 
 import java.util.List;
 
@@ -29,7 +28,7 @@ import java.util.List;
  *
  * @author Daniel Persson
  */
-public class RescueCodeShowActivity extends AppCompatActivity {
+public class RescueCodeShowActivity extends CommonBaseActivity {
     private static final String TAG = "RescueCodeShowActivity";
 
     @Override
@@ -79,13 +78,6 @@ public class RescueCodeShowActivity extends AppCompatActivity {
                 showPrintingNotAvailableDialog();
             }
         });
-    }
-
-    @Override
-    protected void onResume() {
-        super.onResume();
-        Utils.setLanguage(this);
-        Utils.reloadActivityTitle(this);
     }
 
     public void showPrintingNotAvailableDialog() {

--- a/app/src/main/java/org/ea/sqrl/activites/create/RescueCodeShowActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/create/RescueCodeShowActivity.java
@@ -85,6 +85,7 @@ public class RescueCodeShowActivity extends AppCompatActivity {
     protected void onResume() {
         super.onResume();
         Utils.setLanguage(this);
+        Utils.reloadActivityTitle(this);
     }
 
     public void showPrintingNotAvailableDialog() {

--- a/app/src/main/java/org/ea/sqrl/activites/create/RescueCodeShowActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/create/RescueCodeShowActivity.java
@@ -38,8 +38,6 @@ public class RescueCodeShowActivity extends AppCompatActivity {
         setContentView(R.layout.activity_rescuecode_show);
         AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_AUTO);
 
-        Utils.setLanguage(this);
-
         try {
             final EntropyHarvester entropyHarvester = EntropyHarvester.getInstance();
             SQRLStorage storage = SQRLStorage.getInstance(RescueCodeShowActivity.this.getApplicationContext());
@@ -81,6 +79,12 @@ public class RescueCodeShowActivity extends AppCompatActivity {
                 showPrintingNotAvailableDialog();
             }
         });
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        Utils.setLanguage(this);
     }
 
     public void showPrintingNotAvailableDialog() {

--- a/app/src/main/java/org/ea/sqrl/activites/identity/ClearIdentityActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/identity/ClearIdentityActivity.java
@@ -1,7 +1,6 @@
 package org.ea.sqrl.activites.identity;
 
 import android.graphics.drawable.Drawable;
-import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatDelegate;
 import android.util.Log;
@@ -9,8 +8,8 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import org.ea.sqrl.R;
+import org.ea.sqrl.activites.base.CommonBaseActivity;
 import org.ea.sqrl.processors.SQRLStorage;
-import org.ea.sqrl.utils.Utils;
 
 import java.security.KeyStore;
 
@@ -18,7 +17,7 @@ import java.security.KeyStore;
  *
  * @author Daniel Persson
  */
-public class ClearIdentityActivity extends AppCompatActivity {
+public class ClearIdentityActivity extends CommonBaseActivity {
     private static final String TAG = "ClearIdentityActivity";
 
     @Override
@@ -56,12 +55,5 @@ public class ClearIdentityActivity extends AppCompatActivity {
         } catch (Exception e) {
             Log.e(TAG, e.getMessage(), e);
         }
-    }
-
-    @Override
-    protected void onResume() {
-        super.onResume();
-        Utils.setLanguage(this);
-        Utils.reloadActivityTitle(this);
     }
 }

--- a/app/src/main/java/org/ea/sqrl/activites/identity/ClearIdentityActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/identity/ClearIdentityActivity.java
@@ -62,5 +62,6 @@ public class ClearIdentityActivity extends AppCompatActivity {
     protected void onResume() {
         super.onResume();
         Utils.setLanguage(this);
+        Utils.reloadActivityTitle(this);
     }
 }

--- a/app/src/main/java/org/ea/sqrl/activites/identity/ClearIdentityActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/identity/ClearIdentityActivity.java
@@ -27,8 +27,6 @@ public class ClearIdentityActivity extends AppCompatActivity {
         setContentView(R.layout.activity_clear_identity);
         AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_AUTO);
 
-        Utils.setLanguage(this);
-
         final ImageView imgClearIdentity = findViewById(R.id.imgClearIdentity);
         final TextView txtClearIdentity = findViewById(R.id.txtClearIdentity);
 
@@ -58,5 +56,11 @@ public class ClearIdentityActivity extends AppCompatActivity {
         } catch (Exception e) {
             Log.e(TAG, e.getMessage(), e);
         }
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        Utils.setLanguage(this);
     }
 }

--- a/app/src/main/java/org/ea/sqrl/utils/Utils.java
+++ b/app/src/main/java/org/ea/sqrl/utils/Utils.java
@@ -1,9 +1,6 @@
 package org.ea.sqrl.utils;
 
 import android.app.Activity;
-import android.app.AlarmManager;
-import android.app.PendingIntent;
-import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -11,8 +8,6 @@ import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.os.Build;
 import android.preference.PreferenceManager;
-import android.support.v4.content.IntentCompat;
-import android.util.AndroidException;
 import android.util.Log;
 
 import com.google.zxing.FormatException;
@@ -99,21 +94,5 @@ public class Utils {
         byte[] identityData = aDbHelper.getIdentityData(currentId);
         SQRLStorage sqrlStorage = SQRLStorage.getInstance(activity);
         sqrlStorage.read(identityData);
-    }
-
-    public static void restartApp(Context context) {
-        PackageManager pm = context.getPackageManager();
-        Intent intent = pm.getLaunchIntentForPackage(context.getPackageName());
-        if (intent == null) return;
-
-        ComponentName componentName = intent.getComponent();
-        Intent mainIntent = Intent.makeRestartActivityTask(componentName);
-        mainIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
-        context.startActivity(mainIntent);
-
-        if (context instanceof Activity) {
-            ((Activity) context).finish();
-        }
-        Runtime.getRuntime().exit(0);
     }
 }


### PR DESCRIPTION
Issues #310, #218.

Description:
This should fix the "*language only partly updating*" as well as the "*language of activity title not updating*" bugs.

Changes:
Moved language update and activity title update code to `onCreate()` and added code to detect language changes in `onResume()`. If a language change is detected, the activity gets recreated, which ensures proper loading of all language assets. 

Added `CommonBaseActivity` that *EVERY* other activity inherits from (either directly or indirectly) and put the language update and language change detection code there. This way, every activity gets this functionality "for free" without dupliacting any code. This class could come in handy later as well if we need more common code.

As discussed in issue #310, we might consider refactoring the base activity names, which I would leave up to you, @kalaspuffar :)

