### PR TITLE
Handle .sqrl file intent

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -128,7 +128,8 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="file" />
                 <data android:scheme="content" />
-                <data android:mimeType="text/plain" />
+                <data android:mimeType="text/*" />
+                <data android:mimeType="application/*" />
             </intent-filter>
         </activity>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -118,8 +118,19 @@
             />
 
         <activity android:name=".activites.identity.ImportActivity"
-            android:label="@string/title_import"
-            />
+            android:label="@string/title_import">
+            <intent-filter
+                android:icon="@drawable/ic_sqrl_icon_vector_outline"
+                android:label="@string/app_name"
+                android:priority="50" >
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="file" />
+                <data android:scheme="content" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
+        </activity>
 
         <activity android:name=".activites.account.AccountOptionsActivity"
             android:label="@string/title_account_options"

--- a/app/src/main/java/org/ea/sqrl/activites/identity/ImportActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/identity/ImportActivity.java
@@ -130,9 +130,10 @@ public class ImportActivity extends BaseActivity {
             return;
         }
 
-        if (getIntent().getAction() != null && getIntent().getType() != null &&
-                getIntent().getAction().equals(Intent.ACTION_VIEW) &&
-                getIntent().getType().startsWith("text/")) {
+        Intent intent = getIntent();
+        if (intent.getAction() != null && intent.getType() != null &&
+                intent.getAction().equals(Intent.ACTION_VIEW) &&
+                (intent.getType().startsWith("text/") || intent.getType().startsWith("application/"))) {
             handleFileIntent();
             return;
         }

--- a/app/src/main/java/org/ea/sqrl/utils/Utils.java
+++ b/app/src/main/java/org/ea/sqrl/utils/Utils.java
@@ -15,6 +15,7 @@ import com.google.zxing.FormatException;
 import org.ea.sqrl.database.IdentityDBHelper;
 import org.ea.sqrl.processors.SQRLStorage;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Locale;
@@ -83,12 +84,19 @@ public class Utils {
     public static byte[] getFileIntentContent(Context context, Uri contentUri) {
         if (contentUri == null) return null;
 
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        byte[] buffer = new byte[1024];
+        int len;
+
         try {
             InputStream inputStream = context.getContentResolver().openInputStream(contentUri);
-            byte[] data = new byte[inputStream.available()];
-            inputStream.read(data);
+
+            while ((len = inputStream.read(buffer)) != -1) {
+                os.write(buffer, 0, len);
+            }
+
             inputStream.close();
-            return data;
+            return os.toByteArray();
 
         } catch (IOException e) {
             e.printStackTrace();

--- a/app/src/main/java/org/ea/sqrl/utils/Utils.java
+++ b/app/src/main/java/org/ea/sqrl/utils/Utils.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
+import android.net.Uri;
 import android.os.Build;
 import android.preference.PreferenceManager;
 import android.util.Log;
@@ -14,6 +15,8 @@ import com.google.zxing.FormatException;
 import org.ea.sqrl.database.IdentityDBHelper;
 import org.ea.sqrl.processors.SQRLStorage;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Locale;
 
 /**
@@ -75,5 +78,21 @@ public class Utils {
         byte[] identityData = aDbHelper.getIdentityData(currentId);
         SQRLStorage sqrlStorage = SQRLStorage.getInstance(activity);
         sqrlStorage.read(identityData);
+    }
+
+    public static byte[] getFileIntentContent(Context context, Uri contentUri) {
+        if (contentUri == null) return null;
+
+        try {
+            InputStream inputStream = context.getContentResolver().openInputStream(contentUri);
+            byte[] data = new byte[inputStream.available()];
+            inputStream.read(data);
+            inputStream.close();
+            return data;
+
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        }
     }
 }

--- a/app/src/main/res/layout-land/activity_import.xml
+++ b/app/src/main/res/layout-land/activity_import.xml
@@ -28,7 +28,7 @@
     </android.support.design.widget.TextInputLayout>
 
     <TextView
-        android:id="@+id/textView2"
+        android:id="@+id/txtImportMessage"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginEnd="16dp"
@@ -62,7 +62,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="1.0"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/textView2" />
+        app:layout_constraintTop_toBottomOf="@+id/txtImportMessage" />
 
     <Button
         android:id="@+id/btnForgotPassword"

--- a/app/src/main/res/layout/activity_import.xml
+++ b/app/src/main/res/layout/activity_import.xml
@@ -28,7 +28,7 @@
     </android.support.design.widget.TextInputLayout>
 
     <TextView
-        android:id="@+id/textView2"
+        android:id="@+id/txtImportMessage"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginEnd="16dp"
@@ -64,7 +64,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="1.0"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/textView2" />
+        app:layout_constraintTop_toBottomOf="@+id/txtImportMessage" />
 
     <Button
         android:id="@+id/btnForgotPassword"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -240,4 +240,5 @@
 <string name="img_password_contains_symbols">Indicates whether the password contains symbols</string>
 <string name="short_password_warning">You are using a very short password. This is highly insecure and should absolutely be avoided!</string>
 <string name="rescue_code_incorrect">Incorrect</string>
+<string name="invalid_sqrl_file">This file does not appear to be a valid SQRL identity file.</string>
 </resources>


### PR DESCRIPTION
Issue #260.

Description:
Enable .sqrl identity file import by choosing the SQRL app in the "*open with app*" android dialog after tapping on a .sqrl file in downloads or a file explorer app.

Changes:
Register an intent filter in the manifest for `ImportActivity` to receive file `VIEW` intents for the mime types `text/*` and `application/*`. Detect such an intent in `onCreate()` and handle it the same way as the QR import would. In case of an invalid file, all buttons are disabled and an error message is displayed in the activity's description TextView.

I guess we'll see how this works on different APIs/devices, since there apparently were a lot of changes in this particular Android API over time and it's a BIG MESS!! Maybe we'll have to broaden the mime types in the future.
