### PR TITLE
File import feature and import UI consolidation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -117,6 +117,10 @@
             android:label="@string/title_export_options"
             />
 
+        <activity android:name=".activites.identity.ImportOptionsActivity"
+            android:label="@string/title_import_options"
+            />
+
         <activity android:name=".activites.identity.ImportActivity"
             android:label="@string/title_import">
             <intent-filter

--- a/app/src/main/java/org/ea/sqrl/activites/MainActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/MainActivity.java
@@ -24,10 +24,9 @@ import org.ea.sqrl.activites.create.CreateIdentityActivity;
 import org.ea.sqrl.activites.create.RekeyIdentityActivity;
 import org.ea.sqrl.activites.identity.ChangePasswordActivity;
 import org.ea.sqrl.activites.identity.ExportOptionsActivity;
-import org.ea.sqrl.activites.identity.ImportActivity;
+import org.ea.sqrl.activites.identity.ImportOptionsActivity;
 import org.ea.sqrl.activites.identity.RenameActivity;
 import org.ea.sqrl.activites.identity.ResetPasswordActivity;
-import org.ea.sqrl.activites.identity.TextImportActivity;
 import org.ea.sqrl.processors.CommunicationFlowHandler;
 import org.ea.sqrl.processors.CommunicationHandler;
 import org.ea.sqrl.processors.SQRLStorage;
@@ -81,7 +80,7 @@ public class MainActivity extends LoginBaseActivity {
 
         final ImageButton btnCloseMain = findViewById(R.id.btnCloseMain);
         btnCloseMain.setOnClickListener(v -> MainActivity.this.finish());
-        
+
         btnUseIdentity = findViewById(R.id.btnUseIdentity);
         btnUseIdentity.setOnClickListener(
                 v -> {
@@ -91,9 +90,9 @@ public class MainActivity extends LoginBaseActivity {
                 }
         );
 
-        final Button btnImportIdentity = findViewById(R.id.btnImportIdentity);
-        btnImportIdentity.setOnClickListener(
-                v -> startActivity(new Intent(this, ImportActivity.class))
+        final Button btnImport = findViewById(R.id.btnImport);
+        btnImport.setOnClickListener(
+                v -> startActivity(new Intent(this, ImportOptionsActivity.class))
         );
 
         final Button btnSettings = findViewById(R.id.btnSettings);
@@ -155,12 +154,6 @@ public class MainActivity extends LoginBaseActivity {
         btnReset.setOnClickListener(
                 v -> startActivity(new Intent(this, ResetPasswordActivity.class))
         );
-
-        final Button btnTextImport = findViewById(R.id.btnTextImport);
-        btnTextImport.setOnClickListener(
-                v -> startActivity(new Intent(this, TextImportActivity.class))
-        );
-
 
         final Button btnCreate = findViewById(R.id.btnCreate);
         btnCreate.setOnClickListener(v -> startActivity(new Intent(this, CreateIdentityActivity.class)));

--- a/app/src/main/java/org/ea/sqrl/activites/identity/ImportOptionsActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/identity/ImportOptionsActivity.java
@@ -1,0 +1,40 @@
+package org.ea.sqrl.activites.identity;
+
+import android.content.Intent;
+import android.os.Bundle;
+
+import org.ea.sqrl.R;
+import org.ea.sqrl.activites.base.BaseActivity;
+
+public class ImportOptionsActivity extends BaseActivity {
+    private static final String TAG = "ImportOptionsActivity";
+    public static final String EXTRA_IMPORT_METHOD = "ImportMethod";
+    public static final String IMPORT_METHOD_QRCODE = "QR_CODE";
+    public static final String IMPORT_METHOD_FILE = "FILE";
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_import_options);
+
+        setupProgressPopupWindow(getLayoutInflater());
+        setupErrorPopupWindow(getLayoutInflater());
+
+        findViewById(R.id.btnScanQRCode).setOnClickListener(v -> {
+            Intent importIdentityIntent = new Intent(this, ImportActivity.class);
+            importIdentityIntent.putExtra(EXTRA_IMPORT_METHOD, IMPORT_METHOD_QRCODE);
+            startActivity(importIdentityIntent);
+        });
+
+        findViewById(R.id.btnPickIdentityFile).setOnClickListener(v -> {
+            Intent importIdentityIntent = new Intent(this, ImportActivity.class);
+            importIdentityIntent.putExtra(EXTRA_IMPORT_METHOD, IMPORT_METHOD_FILE);
+            startActivity(importIdentityIntent);
+        });
+
+        findViewById(R.id.btnTextImport).setOnClickListener(v -> {
+            Intent textImportIntent = new Intent(this, TextImportActivity.class);
+            startActivity(textImportIntent);
+        });
+    }
+}

--- a/app/src/main/res/layout/activity_import_options.xml
+++ b/app/src/main/res/layout/activity_import_options.xml
@@ -1,0 +1,50 @@
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:id="@+id/importOptionsActivityView"
+    tools:context="org.ea.sqrl.activites.identity.ImportOptionsActivity">
+
+    <Button
+        android:id="@+id/btnScanQRCode"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="24dp"
+        android:duplicateParentState="true"
+        android:text="@string/button_scan_secret"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <Button
+        android:id="@+id/btnPickIdentityFile"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:duplicateParentState="true"
+        android:text="@string/import_identity_file"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/btnScanQRCode" />
+
+    <Button
+        android:id="@+id/btnTextImport"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:duplicateParentState="true"
+        android:text="@string/button_text_import"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/btnPickIdentityFile" />
+
+
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -82,7 +82,7 @@
                 tools:layout_conversion_absoluteWidth="304dp" />
 
             <Button
-                android:id="@+id/btnImportIdentity"
+                android:id="@+id/btnImport"
                 android:layout_width="0dp"
                 android:layout_height="48dp"
                 android:layout_marginEnd="16dp"
@@ -152,12 +152,14 @@
                 android:layout_marginEnd="16dp"
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="16dp"
+                android:layout_marginBottom="16dp"
                 android:duplicateParentState="true"
                 android:text="@string/button_create_identity"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintHorizontal_bias="0.0"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/btnRekey"
+                app:layout_constraintBottom_toBottomOf="parent"
                 tools:layout_conversion_absoluteHeight="48dp"
                 tools:layout_conversion_absoluteWidth="304dp" />
 
@@ -189,7 +191,7 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintHorizontal_bias="0.0"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/btnImportIdentity"
+                app:layout_constraintTop_toBottomOf="@+id/btnImport"
                 tools:layout_conversion_absoluteHeight="48dp"
                 tools:layout_conversion_absoluteWidth="304dp" />
 
@@ -224,21 +226,6 @@
                 tools:layout_conversion_absoluteHeight="48dp"
                 tools:layout_conversion_absoluteWidth="304dp" />
 
-            <Button
-                android:id="@+id/btnTextImport"
-                android:layout_width="0dp"
-                android:layout_height="48dp"
-                android:layout_marginBottom="16dp"
-                android:layout_marginEnd="16dp"
-                android:layout_marginLeft="16dp"
-                android:layout_marginRight="16dp"
-                android:layout_marginStart="16dp"
-                android:layout_marginTop="16dp"
-                android:text="@string/button_text_import"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/btnCreate" />
         </android.support.constraint.ConstraintLayout>
     </ScrollView>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -241,4 +241,7 @@
 <string name="short_password_warning">You are using a very short password. This is highly insecure and should absolutely be avoided!</string>
 <string name="rescue_code_incorrect">Incorrect</string>
 <string name="invalid_sqrl_file">This file does not appear to be a valid SQRL identity file.</string>
+<string name="import_identity_file">Import identity file</string>
+<string name="title_import_options">SQRL - Import</string>
+<string name="install_file_manager_app">Please install a file manager app from the Google Play Store!</string>
 </resources>


### PR DESCRIPTION
Issue #314.

Description:

Enable importing a sqrl identity file from within the app. Also, consolidate the import UI.

Changes:
- Implement `Intent.ACTION_GET_CONTENT` to pick an identity file for import
- Add `ImportOptionsActivity` which now hosts all currently available import-options:
  - Scan identity qr code
  - Import identity file
  - Import with text input

![import_options](https://user-images.githubusercontent.com/4005543/57802857-32398000-7757-11e9-92c0-3fb1cb24e875.JPG)
