### PR TITLE
Feature: Show identity name in SimplifiedActivity

### DIFF
--- a/app/src/main/java/org/ea/sqrl/activites/SimplifiedActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/SimplifiedActivity.java
@@ -3,16 +3,15 @@ package org.ea.sqrl.activites;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.graphics.drawable.Drawable;
 import android.hardware.biometrics.BiometricPrompt;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.CancellationSignal;
 import android.support.design.widget.Snackbar;
-import android.support.v7.content.res.AppCompatResources;
-import android.support.v7.widget.AppCompatButton;
+import android.text.SpannableString;
+import android.text.style.UnderlineSpan;
 import android.util.Log;
-import android.widget.Button;
+import android.view.View;
 import android.widget.ImageButton;
 import android.widget.TextView;
 
@@ -39,6 +38,9 @@ import javax.crypto.Cipher;
 public class SimplifiedActivity extends LoginBaseActivity {
     private static final String TAG = "SimplifiedActivity";
 
+    private TextView txtSelectedIdentityHeadline = null;
+    private TextView txtSelectedIdentity = null;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -46,6 +48,16 @@ public class SimplifiedActivity extends LoginBaseActivity {
 
         rootView = findViewById(R.id.simplifiedActivityView);
         communicationFlowHandler = CommunicationFlowHandler.getInstance(this, handler);
+
+        txtSelectedIdentityHeadline = findViewById(R.id.txtSelectedIdentityHeadline);
+        txtSelectedIdentityHeadline.append(":");
+
+        txtSelectedIdentity = findViewById(R.id.txtSelectedIdentity);
+        txtSelectedIdentity.setOnClickListener(
+                v -> {
+                    startActivity(new Intent(this, MainActivity.class));
+                }
+        );
 
         final IntentIntegrator integrator = new IntentIntegrator(this);
         integrator.setDesiredBarcodeFormats(IntentIntegrator.QR_CODE_TYPES);
@@ -87,6 +99,22 @@ public class SimplifiedActivity extends LoginBaseActivity {
                 SQRLStorage storage = SQRLStorage.getInstance(SimplifiedActivity.this.getApplicationContext());
                 try {
                     storage.read(identityData);
+
+                    if (mDbHelper.getIdentities().size() > 1) {
+                        String identityName = mDbHelper.getIdentityName(currentId);
+                        if (identityName.length() > 20) {
+                            identityName = identityName.substring(0, 20) + "...";
+                        }
+                        SpannableString ssIdentityName = new SpannableString(identityName);
+                        ssIdentityName.setSpan(new UnderlineSpan(), 0, ssIdentityName.length(), 0);
+                        txtSelectedIdentity.setText(ssIdentityName);
+                        txtSelectedIdentity.setVisibility(View.VISIBLE);
+                        txtSelectedIdentityHeadline.setVisibility(View.VISIBLE);
+                    } else {
+                        txtSelectedIdentityHeadline.setVisibility(View.GONE);
+                        txtSelectedIdentity.setVisibility(View.GONE);
+                    }
+
                 } catch (Exception e) {
                     showErrorMessage(e.getMessage());
                     Log.e(TAG, e.getMessage(), e);

--- a/app/src/main/java/org/ea/sqrl/activites/base/LoginBaseActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/base/LoginBaseActivity.java
@@ -128,7 +128,7 @@ public class LoginBaseActivity extends BaseActivity implements AdapterView.OnIte
     }
 
     protected void updateSpinnerData(long currentId) {
-        identities = mDbHelper.getIdentitys();
+        identities = mDbHelper.getIdentities();
         if (identities.size() == 0) return;
         if(currentId == -1) {
             currentId = identities.keySet().iterator().next();

--- a/app/src/main/java/org/ea/sqrl/database/IdentityDBHelper.java
+++ b/app/src/main/java/org/ea/sqrl/database/IdentityDBHelper.java
@@ -81,7 +81,7 @@ public class IdentityDBHelper extends SQLiteOpenHelper {
         return returnVal;
     }
 
-    public Map<Long, String> getIdentitys() {
+    public Map<Long, String> getIdentities() {
         Cursor cursor = this.getWritableDatabase().query(
                 IdentityEntry.TABLE_NAME,
                 new String[] {
@@ -114,7 +114,7 @@ public class IdentityDBHelper extends SQLiteOpenHelper {
     }
 
     public boolean checkUnique(long id, String name) {
-        for(Map.Entry<Long, String> entry : getIdentitys().entrySet()) {
+        for(Map.Entry<Long, String> entry : getIdentities().entrySet()) {
             if(entry.getKey() != id && entry.getValue().equals(name)) {
                 return false;
             }
@@ -156,12 +156,12 @@ public class IdentityDBHelper extends SQLiteOpenHelper {
     }
 
     public boolean hasIdentities() {
-        Map<Long, String> identities = getIdentitys();
+        Map<Long, String> identities = getIdentities();
         return identities.size() > 0;
     }
 
     public String getIdentityName(long currentId) {
-        Map<Long, String> identities = this.getIdentitys();
+        Map<Long, String> identities = this.getIdentities();
         return identities.get(currentId);
     }
 }

--- a/app/src/main/res/layout/activity_simplified.xml
+++ b/app/src/main/res/layout/activity_simplified.xml
@@ -18,6 +18,40 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
+        <TextView
+            android:id="@+id/txtSelectedIdentityHeadline"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginLeft="8dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginEnd="8dp"
+            android:layout_marginRight="8dp"
+            android:text="@string/main_selected_identity"
+            android:textColor="@android:color/primary_text_dark"
+            android:textSize="10sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/txtSelectedIdentity"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginLeft="8dp"
+            android:layout_marginEnd="8dp"
+            android:layout_marginRight="8dp"
+            android:clickable="true"
+            android:focusable="true"
+            android:singleLine="true"
+            android:text="@string/main_selected_identity"
+            android:textColor="@android:color/primary_text_dark"
+            android:textSize="14sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/txtSelectedIdentityHeadline" />
+
         <ImageButton
             android:id="@+id/btnUseIdentity"
             android:layout_width="200dp"
@@ -29,11 +63,11 @@
             android:scaleType="fitCenter"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/txtSelectedIdentity"
             app:srcCompat="@drawable/ic_scan_qr_black_24dp" />
 
         <TextView
-            android:id="@+id/textView8"
+            android:id="@+id/txtScanQrCode"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="8dp"


### PR DESCRIPTION
Issue #220 .

Description:

Displays the currently selected identity name in the `SimplifiedActivity`, but only if more than one identity is present. Tapping on the identity name will open the screen where one can change the currently active identity. Overlong identity names will be truncated.

<img src="https://user-images.githubusercontent.com/4005543/58050949-1b2cd080-7b51-11e9-8648-584bc2cbc865.jpg" />

Please note that there is already a PR pending regarding this topic, but it was not updated in over two months and the `SimplifiedActivity` has had some changes in the meantime. This tries to take the ideas from that PR and implement them in the current, up-to-date codebase.

Changes:
 - Add `TextView`s to *activity_simplified.xml* to display the identity name
 - Add code to *SimplifiedActivity.java* to show/hide the current identity name
 - Fix typo in mDbHelper: `getIdentitys()` -> `getIdentities()`
