### PR TITLE
Improve MainActivity

### DIFF
--- a/app/src/androidTest/java/org/ea/sqrl/AccessibilityInstrumentedTest.java
+++ b/app/src/androidTest/java/org/ea/sqrl/AccessibilityInstrumentedTest.java
@@ -9,6 +9,7 @@ import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.view.WindowManager;
 
+import org.ea.sqrl.activites.identity.IdentityManagementActivity;
 import org.ea.sqrl.activites.LanguageActivity;
 import org.ea.sqrl.activites.SimplifiedActivity;
 import org.ea.sqrl.activites.account.AccountOptionsActivity;
@@ -20,7 +21,6 @@ import org.ea.sqrl.activites.identity.ClearIdentityActivity;
 import org.ea.sqrl.activites.create.CreateIdentityActivity;
 import org.ea.sqrl.activites.create.EntropyGatherActivity;
 import org.ea.sqrl.activites.IntroductionActivity;
-import org.ea.sqrl.activites.MainActivity;
 import org.ea.sqrl.activites.create.NewIdentityDoneActivity;
 import org.ea.sqrl.activites.create.RekeyIdentityActivity;
 import org.ea.sqrl.activites.create.RekeyVerifyActivity;
@@ -36,7 +36,6 @@ import org.ea.sqrl.activites.identity.ShowIdentityActivity;
 import org.ea.sqrl.activites.StartActivity;
 import org.ea.sqrl.activites.UrlLoginActivity;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -72,8 +71,8 @@ public class AccessibilityInstrumentedTest {
             new ActivityTestRule<>(IntroductionActivity.class, true, false);
 
     @Rule
-    public ActivityTestRule<MainActivity> mainActivityRule =
-            new ActivityTestRule<>(MainActivity.class, true, false);
+    public ActivityTestRule<IdentityManagementActivity> identityManagementActivityRule =
+            new ActivityTestRule<>(IdentityManagementActivity.class, true, false);
 
     @Rule
     public ActivityTestRule<NewIdentityDoneActivity> newIdentityDoneActivityRule =
@@ -229,12 +228,12 @@ public class AccessibilityInstrumentedTest {
     public void testMainActivityAccessibility() throws Exception {
         Context targetContext = InstrumentationRegistry.getInstrumentation()
                 .getTargetContext();
-        Intent intent = new Intent(targetContext, MainActivity.class);
+        Intent intent = new Intent(targetContext, IdentityManagementActivity.class);
         intent.putExtra("RUNNING_TEST", true);
-        MainActivity a = mainActivityRule.launchActivity(intent);
+        IdentityManagementActivity a = identityManagementActivityRule.launchActivity(intent);
         unlockScreen(a);
 
-        onView(withId(R.id.mainActivityView)).perform(click());
+        onView(withId(R.id.identityManagementActivityView)).perform(click());
     }
 
     @Test

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,7 +29,7 @@
             />
         <activity
             android:name=".activites.identity.IdentityManagementActivity"
-            android:label="@string/title_activity_advanced"
+            android:label="@string/title_identity_management"
             />
 
         <activity

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
             android:label="@string/app_name"
             />
         <activity
-            android:name=".activites.MainActivity"
+            android:name=".activites.identity.IdentityManagementActivity"
             android:label="@string/title_activity_advanced"
             />
 

--- a/app/src/main/java/org/ea/sqrl/activites/SimplifiedActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/SimplifiedActivity.java
@@ -20,6 +20,7 @@ import com.google.zxing.integration.android.IntentResult;
 
 import org.ea.sqrl.R;
 import org.ea.sqrl.activites.base.LoginBaseActivity;
+import org.ea.sqrl.activites.identity.IdentityManagementActivity;
 import org.ea.sqrl.processors.BioAuthenticationCallback;
 import org.ea.sqrl.processors.CommunicationFlowHandler;
 import org.ea.sqrl.processors.CommunicationHandler;
@@ -55,7 +56,7 @@ public class SimplifiedActivity extends LoginBaseActivity {
         txtSelectedIdentity = findViewById(R.id.txtSelectedIdentity);
         txtSelectedIdentity.setOnClickListener(
                 v -> {
-                    startActivity(new Intent(this, MainActivity.class));
+                    startActivity(new Intent(this, IdentityManagementActivity.class));
                 }
         );
 
@@ -130,7 +131,7 @@ public class SimplifiedActivity extends LoginBaseActivity {
         IntentResult result = IntentIntegrator.parseActivityResult(requestCode, resultCode, data);
         if(result != null) {
             if(result.getContents() == null) {
-                Log.d("MainActivity", "Cancelled scan");
+                Log.d("SimplifiedActivity", "Cancelled scan");
                 Snackbar.make(rootView, R.string.scan_cancel, Snackbar.LENGTH_LONG).show();
                 if(!mDbHelper.hasIdentities()) {
                     startActivity(new Intent(this, StartActivity.class));

--- a/app/src/main/java/org/ea/sqrl/activites/base/BaseActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/base/BaseActivity.java
@@ -37,8 +37,8 @@ import android.widget.TextView;
 
 import org.ea.sqrl.BuildConfig;
 import org.ea.sqrl.R;
+import org.ea.sqrl.activites.identity.IdentityManagementActivity;
 import org.ea.sqrl.activites.LanguageActivity;
-import org.ea.sqrl.activites.MainActivity;
 import org.ea.sqrl.activites.identity.ClearIdentityActivity;
 import org.ea.sqrl.activites.IntroductionActivity;
 import org.ea.sqrl.database.IdentityDBHelper;
@@ -147,7 +147,7 @@ public class BaseActivity extends CommonBaseActivity {
                 startActivity(new Intent(this, LanguageActivity.class));
                 return true;
             case R.id.action_advanced_options:
-                startActivity(new Intent(this, MainActivity.class));
+                startActivity(new Intent(this, IdentityManagementActivity.class));
                 return true;
             case R.id.action_about:
                 AlertDialog.Builder builder;

--- a/app/src/main/java/org/ea/sqrl/activites/create/NewIdentityDoneActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/create/NewIdentityDoneActivity.java
@@ -11,7 +11,6 @@ import android.widget.TextView;
 import org.ea.sqrl.R;
 import org.ea.sqrl.activites.SimplifiedActivity;
 import org.ea.sqrl.activites.identity.ExportOptionsActivity;
-import org.ea.sqrl.activites.MainActivity;
 import org.ea.sqrl.activites.base.LoginBaseActivity;
 import org.ea.sqrl.processors.SQRLStorage;
 

--- a/app/src/main/java/org/ea/sqrl/activites/identity/IdentityManagementActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/identity/IdentityManagementActivity.java
@@ -1,4 +1,4 @@
-package org.ea.sqrl.activites;
+package org.ea.sqrl.activites.identity;
 
 import android.app.AlertDialog;
 import android.content.Context;
@@ -19,14 +19,11 @@ import com.google.zxing.integration.android.IntentIntegrator;
 import com.google.zxing.integration.android.IntentResult;
 
 import org.ea.sqrl.R;
+import org.ea.sqrl.activites.SettingsActivity;
+import org.ea.sqrl.activites.StartActivity;
 import org.ea.sqrl.activites.base.LoginBaseActivity;
 import org.ea.sqrl.activites.create.CreateIdentityActivity;
 import org.ea.sqrl.activites.create.RekeyIdentityActivity;
-import org.ea.sqrl.activites.identity.ChangePasswordActivity;
-import org.ea.sqrl.activites.identity.ExportOptionsActivity;
-import org.ea.sqrl.activites.identity.ImportOptionsActivity;
-import org.ea.sqrl.activites.identity.RenameActivity;
-import org.ea.sqrl.activites.identity.ResetPasswordActivity;
 import org.ea.sqrl.processors.CommunicationFlowHandler;
 import org.ea.sqrl.processors.CommunicationHandler;
 import org.ea.sqrl.processors.SQRLStorage;
@@ -41,19 +38,19 @@ import java.util.regex.Matcher;
  *
  * @author Daniel Persson
  */
-public class MainActivity extends LoginBaseActivity {
-    private static final String TAG = "MainActivity";
+public class IdentityManagementActivity extends LoginBaseActivity {
+    private static final String TAG = "IdentityManagementActivity";
 
     private boolean importIdentity = false;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
+        setContentView(R.layout.activity_identity_management);
 
         cboxIdentity = findViewById(R.id.cboxIdentity);
         txtOneIdentity = findViewById(R.id.txtOneIdentity);
-        rootView = findViewById(R.id.mainActivityView);
+        rootView = findViewById(R.id.identityManagementActivityView);
         communicationFlowHandler = CommunicationFlowHandler.getInstance(this, handler);
 
         ImageView moreIndicator = findViewById(R.id.more_indicator);
@@ -79,7 +76,7 @@ public class MainActivity extends LoginBaseActivity {
         integrator.setBarcodeImageEnabled(false);
 
         final ImageButton btnCloseMain = findViewById(R.id.btnCloseMain);
-        btnCloseMain.setOnClickListener(v -> MainActivity.this.finish());
+        btnCloseMain.setOnClickListener(v -> IdentityManagementActivity.this.finish());
 
         btnUseIdentity = findViewById(R.id.btnUseIdentity);
         btnUseIdentity.setOnClickListener(
@@ -106,7 +103,7 @@ public class MainActivity extends LoginBaseActivity {
                     DialogInterface.OnClickListener dialogClickListener = (dialog, which) -> {
                         switch (which){
                             case DialogInterface.BUTTON_POSITIVE:
-                                SharedPreferences sharedPref = MainActivity.this.getApplication().getSharedPreferences(
+                                SharedPreferences sharedPref = IdentityManagementActivity.this.getApplication().getSharedPreferences(
                                         APPS_PREFERENCES,
                                         Context.MODE_PRIVATE
                                 );
@@ -117,7 +114,7 @@ public class MainActivity extends LoginBaseActivity {
                                     Snackbar.make(rootView, getString(R.string.main_identity_removed), Snackbar.LENGTH_LONG).show();
 
                                     if(!mDbHelper.hasIdentities()) {
-                                        startActivity(new Intent(MainActivity.this, StartActivity.class));
+                                        startActivity(new Intent(IdentityManagementActivity.this, StartActivity.class));
                                     }
                                 }
                                 break;
@@ -127,7 +124,7 @@ public class MainActivity extends LoginBaseActivity {
                         }
                     };
 
-                    AlertDialog.Builder builder = new AlertDialog.Builder(MainActivity.this);
+                    AlertDialog.Builder builder = new AlertDialog.Builder(IdentityManagementActivity.this);
                     builder.setMessage(R.string.remove_identity_confirmation)
                             .setNegativeButton(R.string.remove_identity_confirmation_negative, dialogClickListener)
                             .setPositiveButton(R.string.remove_identity_confirmation_positive, dialogClickListener)
@@ -167,7 +164,7 @@ public class MainActivity extends LoginBaseActivity {
         if (loginPopupWindow != null && loginPopupWindow.isShowing()) {
             hideLoginPopup();
         } else {
-            MainActivity.this.finish();
+            IdentityManagementActivity.this.finish();
         }
     }
 
@@ -179,7 +176,7 @@ public class MainActivity extends LoginBaseActivity {
         if(runningTest || importIdentity) return;
 
         if(!mDbHelper.hasIdentities()) {
-            MainActivity.this.finish();
+            IdentityManagementActivity.this.finish();
         } else {
             setupBasePopups(getLayoutInflater(), false);
 
@@ -199,10 +196,10 @@ public class MainActivity extends LoginBaseActivity {
         IntentResult result = IntentIntegrator.parseActivityResult(requestCode, resultCode, data);
         if(result != null) {
             if(result.getContents() == null) {
-                Log.d("MainActivity", "Cancelled scan");
+                Log.d("IdentityManagementActivity", "Cancelled scan");
                 Snackbar.make(rootView, R.string.scan_cancel, Snackbar.LENGTH_LONG).show();
                 if(!mDbHelper.hasIdentities()) {
-                    MainActivity.this.finish();
+                    IdentityManagementActivity.this.finish();
                 }
             } else {
                 if(!importIdentity) {
@@ -231,7 +228,7 @@ public class MainActivity extends LoginBaseActivity {
                         final TextView txtSite = loginPopupWindow.getContentView().findViewById(R.id.txtSite);
                         txtSite.setText(domain);
 
-                        SQRLStorage storage = SQRLStorage.getInstance(MainActivity.this.getApplicationContext());
+                        SQRLStorage storage = SQRLStorage.getInstance(IdentityManagementActivity.this.getApplicationContext());
                         final TextView txtLoginPassword = loginPopupWindow.getContentView().findViewById(R.id.txtLoginPassword);
                         if(storage.hasQuickPass()) {
                             txtLoginPassword.setHint(getString(R.string.login_identity_quickpass, "" + storage.getHintLength()));

--- a/app/src/main/res/layout/activity_identity_management.xml
+++ b/app/src/main/res/layout/activity_identity_management.xml
@@ -4,8 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:id="@+id/mainActivityView"
-    tools:context="org.ea.sqrl.activites.MainActivity">
+    android:id="@+id/identityManagementActivityView"
+    tools:context="org.ea.sqrl.activites.identity.IdentityManagementActivity">
 
     <ImageButton
         android:id="@+id/btnCloseMain"

--- a/app/src/main/res/layout/activity_identity_management.xml
+++ b/app/src/main/res/layout/activity_identity_management.xml
@@ -19,7 +19,24 @@
         app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
-        android:id="@+id/textView5"
+        android:id="@+id/txtOneIdentity"
+        android:layout_width="match_parent"
+        android:layout_height="50dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginLeft="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginRight="16dp"
+        android:maxLines="1"
+        android:padding="8dp"
+        android:text=""
+        android:textSize="18sp"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/btnCloseMain" />
+
+    <TextView
+        android:id="@+id/txtCurrentIdentityHeadline"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginEnd="8dp"
@@ -46,7 +63,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/textView5" />
+        app:layout_constraintTop_toBottomOf="@+id/txtCurrentIdentityHeadline" />
 
     <ScrollView
         android:id="@+id/main_scroll"
@@ -65,21 +82,6 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical">
-
-
-            <Button
-                android:id="@+id/btnUseIdentity"
-                android:layout_width="0dp"
-                android:layout_height="48dp"
-                android:layout_marginEnd="16dp"
-                android:layout_marginStart="16dp"
-                android:duplicateParentState="true"
-                android:text="@string/button_use_identity"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                tools:layout_conversion_absoluteHeight="48dp"
-                tools:layout_conversion_absoluteWidth="304dp" />
 
             <Button
                 android:id="@+id/btnImport"
@@ -125,7 +127,7 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintHorizontal_bias="0.0"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/btnUseIdentity"
+                app:layout_constraintTop_toTopOf="parent"
                 tools:layout_conversion_absoluteHeight="48dp"
                 tools:layout_conversion_absoluteWidth="304dp" />
 
@@ -241,22 +243,5 @@
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
         app:srcCompat="@drawable/list_more_shape" />
-
-    <TextView
-        android:id="@+id/txtOneIdentity"
-        android:layout_width="match_parent"
-        android:layout_height="50dp"
-        android:layout_marginStart="16dp"
-        android:layout_marginLeft="16dp"
-        android:layout_marginEnd="16dp"
-        android:layout_marginRight="16dp"
-        android:maxLines="1"
-        android:padding="8dp"
-        android:text=""
-        android:textSize="18sp"
-        android:visibility="gone"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/btnCloseMain" />
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/activity_identity_management.xml
+++ b/app/src/main/res/layout/activity_identity_management.xml
@@ -84,38 +84,6 @@
             android:orientation="vertical">
 
             <Button
-                android:id="@+id/btnImport"
-                android:layout_width="0dp"
-                android:layout_height="48dp"
-                android:layout_marginEnd="16dp"
-                android:layout_marginStart="16dp"
-                android:layout_marginTop="16dp"
-                android:duplicateParentState="true"
-                android:text="@string/button_import_identity"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.0"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/btnExport"
-                tools:layout_conversion_absoluteHeight="48dp"
-                tools:layout_conversion_absoluteWidth="304dp" />
-
-            <Button
-                android:id="@+id/btnExport"
-                android:layout_width="0dp"
-                android:layout_height="48dp"
-                android:layout_marginEnd="16dp"
-                android:layout_marginStart="16dp"
-                android:layout_marginTop="16dp"
-                android:duplicateParentState="true"
-                android:text="@string/button_export_identity"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintHorizontal_bias="0.0"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/btnSettings"
-                tools:layout_conversion_absoluteHeight="48dp"
-                tools:layout_conversion_absoluteWidth="304dp" />
-
-            <Button
                 android:id="@+id/btnSettings"
                 android:layout_width="0dp"
                 android:layout_height="48dp"
@@ -128,6 +96,39 @@
                 app:layout_constraintHorizontal_bias="0.0"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
+                tools:layout_conversion_absoluteHeight="48dp"
+                tools:layout_conversion_absoluteWidth="304dp" />
+
+            <Button
+                android:id="@+id/btnCreate"
+                android:layout_width="0dp"
+                android:layout_height="48dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginBottom="16dp"
+                android:duplicateParentState="true"
+                android:text="@string/button_create_identity"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/btnSettings"
+                tools:layout_conversion_absoluteHeight="48dp"
+                tools:layout_conversion_absoluteWidth="304dp" />
+
+            <Button
+                android:id="@+id/btnRename"
+                android:layout_width="0dp"
+                android:layout_height="48dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:duplicateParentState="true"
+                android:text="@string/button_rename_identity"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/btnCreate"
                 tools:layout_conversion_absoluteHeight="48dp"
                 tools:layout_conversion_absoluteWidth="304dp" />
 
@@ -148,36 +149,34 @@
                 tools:layout_conversion_absoluteWidth="304dp" />
 
             <Button
-                android:id="@+id/btnCreate"
+                android:id="@+id/btnImport"
                 android:layout_width="0dp"
                 android:layout_height="48dp"
                 android:layout_marginEnd="16dp"
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="16dp"
-                android:layout_marginBottom="16dp"
                 android:duplicateParentState="true"
-                android:text="@string/button_create_identity"
+                android:text="@string/button_import_identity"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintHorizontal_bias="0.0"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/btnRekey"
-                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/btnRemove"
                 tools:layout_conversion_absoluteHeight="48dp"
                 tools:layout_conversion_absoluteWidth="304dp" />
 
             <Button
-                android:id="@+id/btnRename"
+                android:id="@+id/btnExport"
                 android:layout_width="0dp"
                 android:layout_height="48dp"
                 android:layout_marginEnd="16dp"
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="16dp"
                 android:duplicateParentState="true"
-                android:text="@string/button_rename_identity"
+                android:text="@string/button_export_identity"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintHorizontal_bias="0.0"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/btnChangePassword"
+                app:layout_constraintTop_toBottomOf="@+id/btnImport"
                 tools:layout_conversion_absoluteHeight="48dp"
                 tools:layout_conversion_absoluteWidth="304dp" />
 
@@ -193,7 +192,7 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintHorizontal_bias="0.0"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/btnImport"
+                app:layout_constraintTop_toBottomOf="@+id/btnExport"
                 tools:layout_conversion_absoluteHeight="48dp"
                 tools:layout_conversion_absoluteWidth="304dp" />
 
@@ -208,7 +207,7 @@
                 android:text="@string/button_reset_password"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/btnRemove"
+                app:layout_constraintTop_toBottomOf="@+id/btnChangePassword"
                 tools:layout_conversion_absoluteHeight="48dp"
                 tools:layout_conversion_absoluteWidth="304dp" />
 
@@ -219,12 +218,14 @@
                 android:layout_marginEnd="16dp"
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="16dp"
+                android:layout_marginBottom="16dp"
                 android:duplicateParentState="true"
                 android:text="@string/button_rekey_identity"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintHorizontal_bias="0.0"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/btnReset"
+                app:layout_constraintBottom_toBottomOf="parent"
                 tools:layout_conversion_absoluteHeight="48dp"
                 tools:layout_conversion_absoluteWidth="304dp" />
 

--- a/app/src/main/res/menu/menu_default.xml
+++ b/app/src/main/res/menu/menu_default.xml
@@ -16,7 +16,7 @@
     <item
         android:id="@+id/action_advanced_options"
         android:orderInCategory="90"
-        android:title="@string/button_advanced_functions"
+        android:title="@string/identity_management"
         app:showAsAction="never" />
 
     <item

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -246,4 +246,6 @@
 <string name="import_identity_file">Import identity file</string>
 <string name="title_import_options">SQRL - Import</string>
 <string name="install_file_manager_app">Please install a file manager app from the Google Play Store.</string>
+<string name="identity_management">Identity management</string>
+<string name="title_identity_management">SQRL - Identity Management</string>
 </resources>


### PR DESCRIPTION
Issue #317.

Description:
First steps in the discussed refactoring of `MainActivity`.

Changes:
 - Rename `MainActivity` to `IdentityManagementActivity`
 - Rename `Advanced operations` to `Identity management`
 - Remove `Use identity`
 - Reorder buttons on `IdentityManagementActivity` so that corresponding items are closer to each other

This is "part 1" of the changes for this issue, which mainly deals with stuff under the hood. As soon as we've discussed the settings issue and how exactly the consolidation of the buttons should look like, I'll come in with "part 2".
