### PR TITLE
remove login popup after failed password

### DIFF
--- a/app/src/main/java/org/ea/sqrl/activites/base/LoginBaseActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/base/LoginBaseActivity.java
@@ -224,7 +224,11 @@ public class LoginBaseActivity extends BaseActivity implements AdapterView.OnIte
         new Thread(() -> {
             boolean decryptionOk = storage.decryptIdentityKey(txtLoginPassword.getText().toString(), entropyHarvester, usedQuickpass);
             if(!decryptionOk) {
-                showErrorMessage(R.string.decrypt_identity_fail);
+                showErrorMessage(R.string.decrypt_identity_fail, () -> {
+                    if (!usedCps) {
+                        showLoginPopup();
+                    }
+                });
                 handler.post(() -> {
                     txtLoginPassword.setHint(R.string.login_identity_password);
                     txtLoginPassword.setText("");

--- a/app/src/main/java/org/ea/sqrl/activites/base/LoginBaseActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/base/LoginBaseActivity.java
@@ -229,9 +229,6 @@ public class LoginBaseActivity extends BaseActivity implements AdapterView.OnIte
                     txtLoginPassword.setHint(R.string.login_identity_password);
                     txtLoginPassword.setText("");
                     hideProgressPopup();
-                    if (!usedCps) {
-                        showLoginPopup();
-                    }
                 });
                 storage.clear();
                 storage.clearQuickPass();


### PR DESCRIPTION
Issue #325 

Description:
Removed the login popup after a failed login attempt.

Changes:
If the user types the wrong password, they will see the error message.  Once they dismiss the error message, the login popup will show as the next action.
