### PR TITLE
Better contrasting colors for night and day mode.

### DIFF
--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -2,7 +2,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <color name="colorPrimary">#303f9f</color>
     <color name="colorPrimaryDark">#303f9f</color>
-    <color name="colorAccent">#7B1FA2</color>
+    <color name="colorAccent">#CE93D8</color>
 
 
     <color name="black_overlay">#66000000</color>


### PR DESCRIPTION
Description:
Look at a Google IO talk about Material design suggesting using 700 and 200 for the colors of different layouts to have good contrasts

Changes:
Use the same color for primaryColor and primaryColorDark so the status bar has the same color as our appbar. Also changed the accentColor to use two new purple colors with the right contrast difference.

What do you think about the new colors? @alexhauser @sengsational @sesam 
