### PR TITLE
Fix "Missing argument" error on biometric login

### DIFF
--- a/app/src/main/java/org/ea/sqrl/activites/SettingsActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/SettingsActivity.java
@@ -163,6 +163,7 @@ public class SettingsActivity extends BaseActivity {
                 return;
             }
             storage.clear();
+            storage.clearQuickPass();
 
             long currentId = SqrlApplication.getCurrentId(this.getApplication());
             mDbHelper.updateIdentityData(currentId, storage.createSaveData());


### PR DESCRIPTION
Issue #329.

**Description:**

Fixes the "Missing argument" error that was encountered when logging in using biometrics after identity settings have been saved. 

The reason for the error was that upon saving the identity, QuickPass state is lost. However, a subsequent call to `storage.hasQuickPass()` woud still return `true` due to a missing call to `storage.clearQuickPass()`.

**Changes:**
- Added a call to `storage.clearQuickPass()` upon saving identity settings.

While this fixes the error at hand, we should still think about a better overall solution, where saving settings can leverage an existing active QuickPass (allow biometric auth instead of full password) and also engage QuickPass on successful password input.
