### PR TITLE
Improve ux in RenameActivity

### DIFF
--- a/app/src/main/java/org/ea/sqrl/activites/identity/RenameActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/identity/RenameActivity.java
@@ -1,8 +1,7 @@
 package org.ea.sqrl.activites.identity;
 
-import android.content.Context;
-import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.view.inputmethod.EditorInfo;
 import android.widget.EditText;
 
 import org.ea.sqrl.R;
@@ -10,26 +9,44 @@ import org.ea.sqrl.activites.base.BaseActivity;
 import org.ea.sqrl.utils.SqrlApplication;
 
 public class RenameActivity extends BaseActivity {
+    private EditText txtIdentityName = null;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_rename);
 
-        final EditText txtIdentityName = findViewById(R.id.txtIdentityName);
+        txtIdentityName = findViewById(R.id.txtIdentityName);
 
         final long currentId = SqrlApplication.getCurrentId(this.getApplication());
 
         if(currentId != 0) {
             txtIdentityName.setText(mDbHelper.getIdentityName(currentId));
+            txtIdentityName.setSelectAllOnFocus(true);
+            txtIdentityName.requestFocus();
         }
 
-        findViewById(R.id.btnRename).setOnClickListener(v -> {
-            if(currentId != 0) {
-                mDbHelper.updateIdentityName(currentId, txtIdentityName.getText().toString());
+        txtIdentityName.setOnEditorActionListener((v, actionId, event) -> {
+            switch (actionId) {
+                case EditorInfo.IME_ACTION_DONE:
+                    doRename();
+                    return true;
+                default:
+                    return false;
             }
-            txtIdentityName.setText("");
-
-            RenameActivity.this.finish();
         });
+
+        findViewById(R.id.btnRename).setOnClickListener(v -> doRename());
+    }
+
+    private void doRename() {
+        final long currentId = SqrlApplication.getCurrentId(this.getApplication());
+
+        if(currentId != 0) {
+            mDbHelper.updateIdentityName(currentId, txtIdentityName.getText().toString());
+        }
+        txtIdentityName.setText("");
+
+        RenameActivity.this.finish();
     }
 }

--- a/app/src/main/java/org/ea/sqrl/activites/identity/RenameActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/identity/RenameActivity.java
@@ -1,7 +1,9 @@
 package org.ea.sqrl.activites.identity;
 
+import android.content.Context;
 import android.os.Bundle;
 import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 
 import org.ea.sqrl.R;
@@ -24,6 +26,8 @@ public class RenameActivity extends BaseActivity {
             txtIdentityName.setText(mDbHelper.getIdentityName(currentId));
             txtIdentityName.setSelectAllOnFocus(true);
             txtIdentityName.requestFocus();
+            InputMethodManager imm = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
+            imm.toggleSoftInput(InputMethodManager.SHOW_FORCED, InputMethodManager.HIDE_IMPLICIT_ONLY);
         }
 
         txtIdentityName.setOnEditorActionListener((v, actionId, event) -> {
@@ -45,7 +49,9 @@ public class RenameActivity extends BaseActivity {
         if(currentId != 0) {
             mDbHelper.updateIdentityName(currentId, txtIdentityName.getText().toString());
         }
-        txtIdentityName.setText("");
+
+        InputMethodManager imm = (InputMethodManager) getSystemService(this.INPUT_METHOD_SERVICE);
+        imm.hideSoftInputFromWindow(txtIdentityName.getWindowToken(), 0);
 
         RenameActivity.this.finish();
     }

--- a/app/src/main/res/layout/activity_rename.xml
+++ b/app/src/main/res/layout/activity_rename.xml
@@ -16,6 +16,7 @@
         android:ems="10"
         android:hint="@string/rename_identity_desc"
         android:inputType="textPersonName"
+        android:imeOptions="actionDone"
         android:nextFocusDown="@+id/btnRename"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
Description:

Just a few small improvements that make renaming identities quicker and less painful.

Changes:

- Focus the text field, select all text and pop up keyboard so that one can immediately start typing a new name
- Add `android:imeOptions="actionDone"` and some code to start the renaming when the Enter/Done button is pressed on the soft keyboard. 
