### PR TITLE
Exclude login activity from history and recent apps

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -159,6 +159,8 @@
         <activity
             android:name=".activites.UrlLoginActivity"
             android:label="@string/title_activity_url_login"
+            android:noHistory="true"
+            android:excludeFromRecents="true"
             >
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />


### PR DESCRIPTION
Issue #355.

Exclude UrlLoginActivity from history and recent apps, so that it is not possible to switch back to a "stale" login window using "recent apps".