### PR TITLE
Improve reset password on import

### DIFF
--- a/app/src/main/java/org/ea/sqrl/activites/identity/ImportActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/identity/ImportActivity.java
@@ -243,7 +243,11 @@ public class ImportActivity extends BaseActivity {
         storage.read(identityData);
 
         if(!storage.hasEncryptedKeys()) {
-            handler.postDelayed(() -> startActivity(new Intent(this, ResetPasswordActivity.class)), 100);
+            handler.postDelayed(() -> {
+                Intent setPasswordIntent = new Intent(this, ResetPasswordActivity.class);
+                setPasswordIntent.putExtra(SQRLStorage.NEW_IDENTITY, true);
+                startActivity(setPasswordIntent);
+            }, 100);
             return;
         }
 

--- a/app/src/main/java/org/ea/sqrl/activites/identity/ImportActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/identity/ImportActivity.java
@@ -248,6 +248,7 @@ public class ImportActivity extends BaseActivity {
                 setPasswordIntent.putExtra(SQRLStorage.NEW_IDENTITY, true);
                 startActivity(setPasswordIntent);
             }, 100);
+            ImportActivity.this.finish();
             return;
         }
 

--- a/app/src/main/java/org/ea/sqrl/activites/identity/ResetPasswordActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/identity/ResetPasswordActivity.java
@@ -1,8 +1,6 @@
 package org.ea.sqrl.activites.identity;
 
-import android.content.Context;
 import android.content.Intent;
-import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.view.View;
 import android.view.ViewGroup;
@@ -35,6 +33,13 @@ public class ResetPasswordActivity extends BaseActivity {
         final ViewGroup pwStrengthMeter = findViewById(R.id.passwordStrengthMeter);
         final ViewGroup rootView = findViewById(R.id.resetPasswordActivityView);
         final Button btnResetPassword = findViewById(R.id.btnResetPassword);
+
+        // activity was started from an identity import, change ui texts accordingly
+        if (newIdentity) {
+            this.setTitle(R.string.title_set_password);
+            txtResetPasswordDescription.setText(R.string.set_password_import_desc);
+            btnResetPassword.setText(R.string.button_set_password);
+        }
 
         new PasswordStrengthMeter(this)
                 .register(txtResetPasswordNewPassword, pwStrengthMeter);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -269,4 +269,7 @@
 <string name="button_identity_options">Identity options</string>
 <string name="identity">Identity</string>
 <string name="language_hindi">Hindi</string>
+<string name="title_set_password">SQRL - Set password</string>
+<string name="button_set_password">Set password</string>
+<string name="set_password_import_desc">Since the identity being imported has no password set, it is required for you to provide the rescue code given to you at identity creation. You will then chose a new password, which your newly imported identity will be secured with.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -269,7 +269,7 @@
 <string name="button_identity_options">Identity options</string>
 <string name="identity">Identity</string>
 <string name="language_hindi">Hindi</string>
-<string name="title_set_password">SQRL - Set password</string>
+<string name="title_set_password">SQRL - Set Password</string>
 <string name="button_set_password">Set password</string>
 <string name="set_password_import_desc">Since the identity being imported has no password set, it is required for you to provide the rescue code given to you at identity creation. You will then chose a new password, which your newly imported identity will be secured with.</string>
 </resources>


### PR DESCRIPTION
Issue #348.

Description:

When the `ResetPasswordActivity` is called from an import job, change the activity title, descriptive text and button text to better reflect that we are "setting a new password" in this case instead of "resetting the password".

Changes:

- Added some strings that better describe what's going on when the `ResetPasswordActivity` was called from an import job
- Added a check if the `ResetPasswordActivity` was called from an import job (by checking if the Intent Extra `SQRLStorage.NEW_IDENTITY` is set to `true`). If it was, the new texts are applied.

Fixes:

- Empty import activity would linger after successful import of an identity without password
- Intent Extra `SQRLStorage.NEW_IDENTITY` was missing when importing an identity without password

