### PR TITLE
Handle scanning an identity qr-code from the main screen

### DIFF
--- a/app/src/main/java/org/ea/sqrl/activites/StartActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/StartActivity.java
@@ -55,8 +55,8 @@ public class StartActivity extends BaseActivity {
             startActivity(new Intent(this, CreateIdentityActivity.class));
         } else {
             Intent importIdentityIntent = new Intent(this, ImportActivity.class);
-            importIdentityIntent.putExtra(ImportOptionsActivity.EXTRA_IMPORT_METHOD,
-                    ImportOptionsActivity.IMPORT_METHOD_QRCODE);
+            importIdentityIntent.putExtra(ImportActivity.EXTRA_IMPORT_METHOD,
+                    ImportActivity.IMPORT_METHOD_QR_CODE);
             startActivity(importIdentityIntent);
         }
     }

--- a/app/src/main/java/org/ea/sqrl/activites/identity/ImportActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/identity/ImportActivity.java
@@ -1,8 +1,6 @@
 package org.ea.sqrl.activites.identity;
 
-import android.content.Context;
 import android.content.Intent;
-import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.constraint.ConstraintLayout;
@@ -28,6 +26,11 @@ import java.util.Arrays;
 public class ImportActivity extends BaseActivity {
     private static final String TAG = "ImportActivity";
     private static final int PICK_FILE_REQUEST_CODE = 1;
+    public static final String EXTRA_IMPORT_METHOD = "import_method";
+    public static final String IMPORT_METHOD_QR_CODE = "qr_code";
+    public static final String IMPORT_METHOD_FORWARDED_QR_CODE = "forwarded_qr_code";
+    public static final String IMPORT_METHOD_FILE = "file";
+    public static final String EXTRA_FORWARDED_QR_CODE = "forwarded_qr_code";
 
     private boolean firstIdentity = false;
     private ConstraintLayout rootView = null;
@@ -135,15 +138,15 @@ public class ImportActivity extends BaseActivity {
             return;
         }
 
-        String importMethod = intent.getStringExtra(ImportOptionsActivity.EXTRA_IMPORT_METHOD);
+        String importMethod = intent.getStringExtra(EXTRA_IMPORT_METHOD);
         if (importMethod == null) return;
 
-        if (importMethod.equals(ImportOptionsActivity.IMPORT_METHOD_FILE)) {
+        if (importMethod.equals(IMPORT_METHOD_FILE)) {
             chooseFile();
             return;
         }
 
-        if (importMethod.equals(ImportOptionsActivity.IMPORT_METHOD_QRCODE)) {
+        if (importMethod.equals(IMPORT_METHOD_QR_CODE)) {
             final IntentIntegrator integrator = new IntentIntegrator(this);
             integrator.setDesiredBarcodeFormats(IntentIntegrator.QR_CODE_TYPES);
             integrator.setCameraId(0);
@@ -153,6 +156,17 @@ public class ImportActivity extends BaseActivity {
 
             integrator.setPrompt(this.getString(R.string.scan_identity));
             integrator.initiateScan();
+        }
+
+        if (importMethod.equals(IMPORT_METHOD_FORWARDED_QR_CODE)) {
+            byte[] identityData = intent.getByteArrayExtra(EXTRA_FORWARDED_QR_CODE);
+            if (identityData == null) return;
+            try {
+                readIdentityData(identityData);
+            } catch (Exception e) {
+                showErrorMessage(e.getMessage());
+                Log.e(TAG, e.getMessage(), e);
+            }
         }
     }
 

--- a/app/src/main/java/org/ea/sqrl/activites/identity/ImportOptionsActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/identity/ImportOptionsActivity.java
@@ -8,9 +8,6 @@ import org.ea.sqrl.activites.base.BaseActivity;
 
 public class ImportOptionsActivity extends BaseActivity {
     private static final String TAG = "ImportOptionsActivity";
-    public static final String EXTRA_IMPORT_METHOD = "ImportMethod";
-    public static final String IMPORT_METHOD_QRCODE = "QR_CODE";
-    public static final String IMPORT_METHOD_FILE = "FILE";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -22,13 +19,13 @@ public class ImportOptionsActivity extends BaseActivity {
 
         findViewById(R.id.btnScanQRCode).setOnClickListener(v -> {
             Intent importIdentityIntent = new Intent(this, ImportActivity.class);
-            importIdentityIntent.putExtra(EXTRA_IMPORT_METHOD, IMPORT_METHOD_QRCODE);
+            importIdentityIntent.putExtra(ImportActivity.EXTRA_IMPORT_METHOD, ImportActivity.IMPORT_METHOD_QR_CODE);
             startActivity(importIdentityIntent);
         });
 
         findViewById(R.id.btnPickIdentityFile).setOnClickListener(v -> {
             Intent importIdentityIntent = new Intent(this, ImportActivity.class);
-            importIdentityIntent.putExtra(EXTRA_IMPORT_METHOD, IMPORT_METHOD_FILE);
+            importIdentityIntent.putExtra(ImportActivity.EXTRA_IMPORT_METHOD, ImportActivity.IMPORT_METHOD_FILE);
             startActivity(importIdentityIntent);
         });
 

--- a/app/src/main/java/org/ea/sqrl/utils/Utils.java
+++ b/app/src/main/java/org/ea/sqrl/utils/Utils.java
@@ -9,7 +9,6 @@ import android.content.res.Resources;
 import android.net.Uri;
 import android.os.Build;
 import android.preference.PreferenceManager;
-import android.util.Log;
 
 import com.google.zxing.FormatException;
 
@@ -48,7 +47,13 @@ public class Utils {
     }
 
     public static String readSQRLQRCodeAsString(Intent data) {
-        return data.getStringExtra("SCAN_RESULT");
+        byte[] qrCode = null;
+        try {
+            qrCode = readSQRLQRCode(data);
+        } catch (FormatException fe) { return null; }
+
+        if (qrCode == null) return null;
+        return new String(qrCode);
     }
 
     public static int getInteger(String s) {


### PR DESCRIPTION
Issue #369.

Description:

Handle scanning an identity qr-code on the main screen scan button by "forwarding" the qr-code data to the `ImportActivity`.

Changes:
- Add new import method named `IMPORT_METHOD_FORWARDED_QR_CODE` as intent extra for `ImportActivity`; Also, I've moved all the static strings used for intent extras from `ImportOptionsActivity` to `ImportActivity`
- Detect the type of qr-code in `SimplifiedActivity` and forward data to `ImportActivity` if an identity qr-code was detected, adding the above import method extra to the intent
- Handle a forwarded identity qr-code in `ImportActivity` if present in the intent extras

I also noticed that we were still using the `readSQRLQRCodeAsString(Intent data)`, which did not iterate over the qr-code byte segments, but instead would only `return data.getStringExtra("SCAN_RESULT")` and therefore sometimes delivered truncated data. I have changed the implementation of this function to use the `readSQRLQRCode(Intent data)` under the hood, which was recently updated to deliver correct results under all cirumstances.


