### PR TITLE
OBSOLETE/DO NOT MERGE: Consolidate login

### DIFF
--- a/app/src/main/java/org/ea/sqrl/activites/SimplifiedActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/SimplifiedActivity.java
@@ -114,105 +114,11 @@ public class SimplifiedActivity extends LoginBaseActivity {
                     return;
                 }
 
-                // A login qr-code was scanned
                 final String serverData = new String(qrCodeData);
                 Intent urlLoginIntent = new Intent(Intent.ACTION_VIEW);
                 urlLoginIntent.setData(Uri.parse(serverData));
                 urlLoginIntent.putExtra(UrlLoginActivity.EXTRA_USE_CPS, false);
                 startActivity(urlLoginIntent);
-
-                /*
-
-                communicationFlowHandler.setServerData(serverData);
-                communicationFlowHandler.setUseSSL(serverData.startsWith("sqrl://"));
-
-                Matcher sqrlMatcher = CommunicationHandler.sqrlPattern.matcher(serverData);
-                if(!sqrlMatcher.matches()) {
-                    showErrorMessage(R.string.scan_incorrect);
-                    return;
-                }
-
-                final String domain = sqrlMatcher.group(1);
-                final String queryLink = sqrlMatcher.group(2);
-
-                try {
-                    communicationFlowHandler.setQueryLink(queryLink);
-                    communicationFlowHandler.setDomain(domain, queryLink);
-                } catch (Exception e) {
-                    showErrorMessage(e.getMessage());
-                    Log.e(TAG, e.getMessage(), e);
-                    return;
-                }
-
-                handler.postDelayed(() -> {
-                    final TextView txtSite = loginPopupWindow.getContentView().findViewById(R.id.txtSite);
-                    txtSite.setText(domain);
-
-                    SQRLStorage storage = SQRLStorage.getInstance(SimplifiedActivity.this.getApplicationContext());
-                    final TextView txtLoginPassword = loginPopupWindow.getContentView().findViewById(R.id.txtLoginPassword);
-                    if(storage.hasQuickPass()) {
-                        txtLoginPassword.setHint(getString(R.string.login_identity_quickpass, "" + storage.getHintLength()));
-                    } else {
-                        txtLoginPassword.setHint(R.string.login_identity_password);
-                    }
-
-                    showLoginPopup();
-
-                    if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && storage.hasBiometric()) {
-
-                        BioAuthenticationCallback biometricCallback =
-                                new BioAuthenticationCallback(SimplifiedActivity.this.getApplicationContext(), () -> {
-                                    handler.post(() -> {
-                                        hideLoginPopup();
-                                        showProgressPopup();
-                                    });
-                                    communicationFlowHandler.addAction(CommunicationFlowHandler.Action.QUERY_WITHOUT_SUK_QRCODE);
-                                    communicationFlowHandler.addAction(CommunicationFlowHandler.Action.LOGIN);
-
-                                    communicationFlowHandler.setDoneAction(() -> {
-                                        storage.clear();
-                                        handler.post(() -> {
-                                            hideProgressPopup();
-                                            closeActivity();
-                                        });
-                                    });
-
-                                    communicationFlowHandler.setErrorAction(() -> {
-                                        storage.clear();
-                                        handler.post(() -> hideProgressPopup());
-                                    });
-
-                                    communicationFlowHandler.handleNextAction();
-                                });
-
-                        BiometricPrompt bioPrompt = new BiometricPrompt.Builder(this)
-                                .setTitle(getString(R.string.login_title))
-                                .setSubtitle(domain)
-                                .setDescription(getString(R.string.login_verify_domain_text))
-                                .setNegativeButton(
-                                    getString(R.string.button_cps_cancel),
-                                    this.getMainExecutor(),
-                                    (dialogInterface, i) -> {}
-                                ).build();
-
-                        CancellationSignal cancelSign = new CancellationSignal();
-                        cancelSign.setOnCancelListener(() -> {});
-
-                        try {
-                            KeyStore keyStore = KeyStore.getInstance("AndroidKeyStore");
-                            keyStore.load(null);
-                            KeyStore.Entry entry = keyStore.getEntry("quickPass", null);
-                            Cipher decCipher = Cipher.getInstance("RSA/ECB/PKCS1PADDING"); //or try with "RSA"
-                            decCipher.init(Cipher.DECRYPT_MODE, ((KeyStore.PrivateKeyEntry) entry).getPrivateKey());
-                            bioPrompt.authenticate(new BiometricPrompt.CryptoObject(decCipher), cancelSign, this.getMainExecutor(), biometricCallback);
-                        } catch (Exception e) {
-                            e.printStackTrace();
-                        }
-                    }
-
-                }, 100);
-
-                */
             }
         }
     }

--- a/app/src/main/java/org/ea/sqrl/activites/SimplifiedActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/SimplifiedActivity.java
@@ -1,13 +1,10 @@
 package org.ea.sqrl.activites;
 
 import android.content.Intent;
-import android.hardware.biometrics.BiometricPrompt;
-import android.os.Build;
+import android.net.Uri;
 import android.os.Bundle;
-import android.os.CancellationSignal;
 import android.support.design.widget.Snackbar;
 import android.util.Log;
-import android.widget.TextView;
 
 import com.google.zxing.FormatException;
 import com.google.zxing.integration.android.IntentIntegrator;
@@ -16,19 +13,13 @@ import com.google.zxing.integration.android.IntentResult;
 import org.ea.sqrl.R;
 import org.ea.sqrl.activites.base.LoginBaseActivity;
 import org.ea.sqrl.activites.identity.ImportActivity;
-import org.ea.sqrl.processors.BioAuthenticationCallback;
 import org.ea.sqrl.processors.CommunicationFlowHandler;
-import org.ea.sqrl.processors.CommunicationHandler;
 import org.ea.sqrl.processors.SQRLStorage;
 import org.ea.sqrl.utils.IdentitySelector;
 import org.ea.sqrl.utils.SqrlApplication;
 import org.ea.sqrl.utils.Utils;
 
-import java.security.KeyStore;
 import java.util.Arrays;
-import java.util.regex.Matcher;
-
-import javax.crypto.Cipher;
 
 /**
  *
@@ -123,7 +114,14 @@ public class SimplifiedActivity extends LoginBaseActivity {
                     return;
                 }
 
+                // A login qr-code was scanned
                 final String serverData = new String(qrCodeData);
+                Intent urlLoginIntent = new Intent(Intent.ACTION_VIEW);
+                urlLoginIntent.setData(Uri.parse(serverData));
+                urlLoginIntent.putExtra(UrlLoginActivity.EXTRA_USE_CPS, false);
+                startActivity(urlLoginIntent);
+
+                /*
 
                 communicationFlowHandler.setServerData(serverData);
                 communicationFlowHandler.setUseSSL(serverData.startsWith("sqrl://"));
@@ -213,6 +211,8 @@ public class SimplifiedActivity extends LoginBaseActivity {
                     }
 
                 }, 100);
+
+                */
             }
         }
     }

--- a/app/src/main/java/org/ea/sqrl/activites/UrlLoginActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/UrlLoginActivity.java
@@ -102,7 +102,7 @@ public class UrlLoginActivity extends LoginBaseActivity {
 
         txtLoginPassword.setOnEditorActionListener((v, actionId, event) -> {
             if(actionId == EditorInfo.IME_ACTION_DONE){
-                doLogin(storage, txtLoginPassword, false, useCps, null,UrlLoginActivity.this);
+                doLogin(storage, txtLoginPassword, false, useCps, true, null, UrlLoginActivity.this);
                 return true;
             }
             return false;
@@ -117,7 +117,7 @@ public class UrlLoginActivity extends LoginBaseActivity {
             public void onTextChanged(CharSequence password, int start, int before, int count) {
                 if (!storage.hasQuickPass()) return;
                 if ((start + count) >= storage.getHintLength()) {
-                    doLogin(storage, txtLoginPassword, true, useCps, null, UrlLoginActivity.this);
+                    doLogin(storage, txtLoginPassword, true, useCps, true, null, UrlLoginActivity.this);
                 }
             }
 
@@ -135,42 +135,15 @@ public class UrlLoginActivity extends LoginBaseActivity {
             long currentId = SqrlApplication.getCurrentId(this.getApplication());
 
             if(currentId != 0) {
-                doLogin(storage, txtLoginPassword, false, useCps, null,this);
+                doLogin(storage, txtLoginPassword, false, useCps, true, null,this);
             }
         });
 
         if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && storage.hasBiometric()) {
             BioAuthenticationCallback biometricCallback =
-                    new BioAuthenticationCallback(UrlLoginActivity.this.getApplicationContext(), () -> {
-
-                        //doLogin(storage, txtLoginPassword, false, useCps, this, this);
-
-
-                        handler.post(() -> showProgressPopup());
-
-                        if (useCps) {
-                            communicationFlowHandler.addAction(CommunicationFlowHandler.Action.QUERY_WITHOUT_SUK);
-                            communicationFlowHandler.addAction(CommunicationFlowHandler.Action.LOGIN_CPS);
-                        } else {
-                            communicationFlowHandler.addAction(CommunicationFlowHandler.Action.QUERY_WITHOUT_SUK_QRCODE);
-                            communicationFlowHandler.addAction(CommunicationFlowHandler.Action.LOGIN);
-                        }
-
-                        communicationFlowHandler.setDoneAction(() -> {
-                            storage.clear();
-                            handler.post(() -> {
-                                hideProgressPopup();
-                                closeActivity();
-                            });
-                        });
-
-                        communicationFlowHandler.setErrorAction(() -> {
-                            storage.clear();
-                            handler.post(() -> hideProgressPopup());
-                        });
-
-                        communicationFlowHandler.handleNextAction();
-                    });
+                    new BioAuthenticationCallback(UrlLoginActivity.this.getApplicationContext(), () ->
+                        doLogin(storage, txtLoginPassword, false, useCps, false, UrlLoginActivity.this, UrlLoginActivity.this)
+                    );
 
             BiometricPrompt bioPrompt = new BiometricPrompt.Builder(this)
                     .setTitle(getString(R.string.login_title))

--- a/app/src/main/java/org/ea/sqrl/activites/account/AlternativeLoginActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/account/AlternativeLoginActivity.java
@@ -39,7 +39,7 @@ public class AlternativeLoginActivity extends LoginBaseActivity {
             long currentId = SqrlApplication.getCurrentId(this.getApplication());
 
             if(currentId != 0) {
-                doLogin(storage, txtLoginPassword, false, false, AlternativeLoginActivity.this, this);
+                doLogin(storage, txtLoginPassword, false, false, true, AlternativeLoginActivity.this, this);
             }
         });
     }

--- a/app/src/main/java/org/ea/sqrl/activites/base/LoginBaseActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/base/LoginBaseActivity.java
@@ -78,7 +78,7 @@ public class LoginBaseActivity extends BaseActivity {
     }
 
     public void hideLoginPopup() {
-        loginPopupWindow.dismiss();
+        if (loginPopupWindow != null) loginPopupWindow.dismiss();
         unlockRotation();
     }
 

--- a/app/src/main/java/org/ea/sqrl/activites/base/LoginBaseActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/base/LoginBaseActivity.java
@@ -148,7 +148,6 @@ public class LoginBaseActivity extends BaseActivity {
     public void doLogin(SQRLStorage storage, EditText txtLoginPassword, boolean usedQuickpass,
                         boolean usedCps, boolean needsDecryption, Activity activityToFinish, Context context) {
         handler.post(() -> {
-            if (!usedCps) hideLoginPopup();
             showProgressPopup();
             closeKeyboard();
 
@@ -156,11 +155,7 @@ public class LoginBaseActivity extends BaseActivity {
                 if (needsDecryption) {
                     boolean decryptionOk = storage.decryptIdentityKey(txtLoginPassword.getText().toString(), entropyHarvester, usedQuickpass);
                     if(!decryptionOk) {
-                        showErrorMessage(R.string.decrypt_identity_fail, () -> {
-                            if (!usedCps) {
-                                showLoginPopup();
-                            }
-                        });
+                        showErrorMessage(R.string.decrypt_identity_fail);
                         handler.post(() -> {
                             txtLoginPassword.setHint(R.string.login_identity_password);
                             txtLoginPassword.setText("");


### PR DESCRIPTION
Issue #338.

**Description:**

Abandon the login popup in favour of `UrlLoginActivity`, which is now also used for qr-code login.

**Changes:**

- Forward the url decoded by the qr-code-scan to `UrlLoginActivity`, also passing in an additional intent extra signalling that CPS is to be deactivated for the current login
- Remove the login code from the biometric login and replace it with a single call to the slightly modified `doLogin()` method.

As reflected in the number of changes (77 additions and 184 deletions), this PR eliminates a lot of duplicate code and should make our login code more consistent and streamlined.

Please note that I have deliberately NOT removed the popup window itself with this PR, this way @sengsational's app shortcuts actually do still work. Dale, this would give you the opportunity to modify the popup layout to your likings, so that you don't have to modify it programmatically and can use it solely for the shortcuts logic.

@kalaspuffar and @sengsational , I hope you guys will find some time to review and test this PR, thanks!