### PR TITLE
Fixing rekey function.

### DIFF
--- a/app/src/main/java/org/ea/sqrl/processors/CommunicationFlowHandler.java
+++ b/app/src/main/java/org/ea/sqrl/processors/CommunicationFlowHandler.java
@@ -256,6 +256,8 @@ public class CommunicationFlowHandler {
             actionStack.push(a);
             lastTIF = commHandler.getTif();
             commHandler.clearLastResponse();
+        } else if(commHandler.isPreviousKeyValid()) {
+            commHandler.loginWithPreviousKey();
         }
 
         if(commHandler.hasAskQuestion() && this.actionStack.isEmpty()) {
@@ -343,7 +345,11 @@ public class CommunicationFlowHandler {
     }
 
     protected void postLogin(CommunicationHandler commHandler, boolean noiptest, boolean clientProvidedSession) throws Exception {
-        String postData = commHandler.createPostParams(commHandler.createClientLogin(noiptest, clientProvidedSession), serverData);
+        String postData = commHandler.createPostParams(
+                commHandler.createClientLogin(entropyHarvester, noiptest, clientProvidedSession),
+                serverData,
+                commHandler.isPreviousKeyValid()
+        );
         commHandler.postRequest(queryLink, postData);
         serverData = commHandler.getResponse();
         queryLink = commHandler.getQueryLink();

--- a/app/src/main/java/org/ea/sqrl/processors/CommunicationHandler.java
+++ b/app/src/main/java/org/ea/sqrl/processors/CommunicationHandler.java
@@ -177,8 +177,10 @@ public class CommunicationHandler {
         sb.append(storage.getOptions(noiptest, requestServerUnlockKey, false));
         sb.append(storage.getSecretIndex(cryptDomain, lastResponse.get("sin")));
         sb.append("idk=" + EncryptionUtils.encodeUrlSafe(storage.getPublicKey(cryptDomain)));
+        sb.append("\r\n");
         if(storage.hasPreviousKeys()) {
-            sb.append("\r\npidk=" + EncryptionUtils.encodeUrlSafe(storage.getPreviousPublicKey(cryptDomain)));
+            sb.append("pidk=" + EncryptionUtils.encodeUrlSafe(storage.getPreviousPublicKey(cryptDomain)));
+            sb.append("\r\n");
         }
         return sb.toString();
     }
@@ -192,8 +194,10 @@ public class CommunicationHandler {
         sb.append(storage.getOptions(noiptest, false, clientProvidedSession));
         sb.append(storage.getSecretIndex(cryptDomain, lastResponse.get("sin")));
         sb.append("idk=" + EncryptionUtils.encodeUrlSafe(storage.getPublicKey(cryptDomain)));
+        sb.append("\r\n");
         if(storage.hasPreviousKeys()) {
-            sb.append("\r\npidk=" + EncryptionUtils.encodeUrlSafe(storage.getPreviousPublicKey(cryptDomain)));
+            sb.append("pidk=" + EncryptionUtils.encodeUrlSafe(storage.getPreviousPublicKey(cryptDomain)));
+            sb.append("\r\n");
         }
         return sb.toString();
     }
@@ -207,8 +211,10 @@ public class CommunicationHandler {
         sb.append(storage.getOptions(noiptest, false, clientProvidedSession));
         sb.append(storage.getSecretIndex(cryptDomain, lastResponse.get("sin")));
         sb.append("idk=" + EncryptionUtils.encodeUrlSafe(storage.getPublicKey(cryptDomain)));
+        sb.append("\r\n");
         if(storage.hasPreviousKeys()) {
-            sb.append("\r\npidk=" + EncryptionUtils.encodeUrlSafe(storage.getPreviousPublicKey(cryptDomain)));
+            sb.append("pidk=" + EncryptionUtils.encodeUrlSafe(storage.getPreviousPublicKey(cryptDomain)));
+            sb.append("\r\n");
         }
         return sb.toString();
     }
@@ -222,8 +228,10 @@ public class CommunicationHandler {
         sb.append(storage.getOptions(noiptest, false, clientProvidedSession));
         sb.append(storage.getSecretIndex(cryptDomain, lastResponse.get("sin")));
         sb.append("idk=" + EncryptionUtils.encodeUrlSafe(storage.getPublicKey(cryptDomain)));
+        sb.append("\r\n");
         if(storage.hasPreviousKeys()) {
-            sb.append("\r\npidk=" + EncryptionUtils.encodeUrlSafe(storage.getPreviousPublicKey(cryptDomain)));
+            sb.append("pidk=" + EncryptionUtils.encodeUrlSafe(storage.getPreviousPublicKey(cryptDomain)));
+            sb.append("\r\n");
         }
         return sb.toString();
     }
@@ -239,13 +247,15 @@ public class CommunicationHandler {
         sb.append(storage.getSecretIndex(cryptDomain, lastResponse.get("sin")));
         sb.append(storage.getServerUnlockKey(entropyHarvester));
         sb.append("idk=" + EncryptionUtils.encodeUrlSafe(storage.getPublicKey(cryptDomain)));
+        sb.append("\r\n");
         if(storage.hasPreviousKeys()) {
-            sb.append("\r\npidk=" + EncryptionUtils.encodeUrlSafe(storage.getPreviousPublicKey(cryptDomain)));
+            sb.append("pidk=" + EncryptionUtils.encodeUrlSafe(storage.getPreviousPublicKey(cryptDomain)));
+            sb.append("\r\n");
         }
         return sb.toString();
     }
 
-    public String createClientLogin(boolean noiptest, boolean clientProvidedSession) throws Exception {
+    public String createClientLogin(EntropyHarvester entropyHarvester, boolean noiptest, boolean clientProvidedSession) throws Exception {
         SQRLStorage storage = SQRLStorage.getInstance(context);
         StringBuilder sb = new StringBuilder();
         sb.append("ver=1\r\n");
@@ -254,8 +264,11 @@ public class CommunicationHandler {
         sb.append(storage.getOptions(noiptest, false, clientProvidedSession));
         sb.append(storage.getSecretIndex(cryptDomain, lastResponse.get("sin")));
         sb.append("idk=" + EncryptionUtils.encodeUrlSafe(storage.getPublicKey(cryptDomain)));
-        if(storage.hasPreviousKeys()) {
-            sb.append("\r\npidk=" + EncryptionUtils.encodeUrlSafe(storage.getPreviousPublicKey(cryptDomain)));
+        sb.append("\r\n");
+        if(storage.willLoginWithPreviousKey()) {
+            sb.append("pidk=" + EncryptionUtils.encodeUrlSafe(storage.getPreviousPublicKey(cryptDomain)));
+            sb.append("\r\n");
+            sb.append(storage.getServerUnlockKey(entropyHarvester));
         }
         return sb.toString();
     }
@@ -596,5 +609,10 @@ public class CommunicationHandler {
             this.cryptDomain,
             alternativeId.replaceAll("[^A-Za-z0-9]", "").getBytes()
         );
+    }
+
+    public void loginWithPreviousKey() {
+        SQRLStorage storage = SQRLStorage.getInstance(context);
+        storage.loginWithPreviousKey();
     }
 }

--- a/app/src/main/java/org/ea/sqrl/processors/SQRLStorage.java
+++ b/app/src/main/java/org/ea/sqrl/processors/SQRLStorage.java
@@ -69,7 +69,7 @@ public class SQRLStorage {
     private boolean hasRescueBlock = false;
     private boolean hasPreviousBlock = false;
     private int previousKeyIndex = 0;
-    //private byte[] biometricKeyEncrypted;
+    private boolean loginWithPreviousKey = false;
 
     private SQRLStorage(Context context) {
         this.context = context;
@@ -90,6 +90,14 @@ public class SQRLStorage {
 
     public void increasePreviousKeyIndex() {
         previousKeyIndex++;
+    }
+
+    public void loginWithPreviousKey() {
+        this.loginWithPreviousKey = true;
+    }
+
+    public boolean willLoginWithPreviousKey() {
+        return this.loginWithPreviousKey;
     }
 
     public void newRescueCode(EntropyHarvester entropyHarvester) {

--- a/app/src/main/java/org/ea/sqrl/processors/SQRLStorage.java
+++ b/app/src/main/java/org/ea/sqrl/processors/SQRLStorage.java
@@ -345,6 +345,7 @@ public class SQRLStorage {
 
     public void cleanIdentity() {
         this.previousKeyIndex = 0;
+        this.loginWithPreviousKey = false;
         this.identityPlaintextLength = -1;
         this.identityPlaintext = null;
         this.initializationVector = null;
@@ -767,6 +768,7 @@ public class SQRLStorage {
 
     public void clearQuickPass() {
         this.previousKeyIndex = 0;
+        this.loginWithPreviousKey = false;
 
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
         SharedPreferences.Editor editor = sharedPreferences.edit();
@@ -785,6 +787,8 @@ public class SQRLStorage {
 
     public void clear() {
         this.previousKeyIndex = 0;
+        this.loginWithPreviousKey = false;
+
         try {
             if(this.identityLockKey != null) {
                 clearBytes(this.identityLockKey);


### PR DESCRIPTION
Description:
When you rekey an identity this identity will have an old previous key and then the new key is put into our secret vault. This means that you will have new suk (server unlock key) and vuk (verify unlock key). These must be communicated with the server when a previous key has been found to be valid.

Changes:
Set a boolean in Storage when a previous key has been found.
Send suk and vuk when previous key is sent to the server.
