### PR TITLE
Improve layout of NewIdentityDoneActivity

### DIFF
--- a/app/src/main/res/drawable/ic_assignment_turned_in_accent_24dp.xml
+++ b/app/src/main/res/drawable/ic_assignment_turned_in_accent_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="@color/colorAccent"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M19,3h-4.18C14.4,1.84 13.3,1 12,1c-1.3,0 -2.4,0.84 -2.82,2L5,3c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2L21,5c0,-1.1 -0.9,-2 -2,-2zM12,3c0.55,0 1,0.45 1,1s-0.45,1 -1,1 -1,-0.45 -1,-1 0.45,-1 1,-1zM10,17l-4,-4 1.41,-1.41L10,14.17l6.59,-6.59L18,9l-8,8z"/>
+</vector>

--- a/app/src/main/res/layout/activity_new_identity_done.xml
+++ b/app/src/main/res/layout/activity_new_identity_done.xml
@@ -7,30 +7,55 @@
     android:id="@+id/newIdentityDoneActivityView"
     tools:context="org.ea.sqrl.activites.create.NewIdentityDoneActivity">
 
-    <TextView
-        android:id="@+id/txtNewIdentityDoneMessage"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="8dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:text="@string/new_identity_done_message"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-    <Button
-        android:id="@+id/btnNewIdentityDone"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginEnd="16dp"
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
         android:layout_marginBottom="16dp"
-        android:text="@string/button_new_identity_done"
-        app:layout_constraintBottom_toBottomOf="parent"
+        android:paddingBottom="16dp"
+        app:layout_constraintBottom_toTopOf="@+id/btnNewIdentityDoneExport"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <android.support.constraint.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <ImageView
+                android:id="@+id/imgCreateIdentitySuccess"
+                android:layout_width="70dp"
+                android:layout_height="70dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginLeft="16dp"
+                android:layout_marginTop="32dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginRight="16dp"
+                android:scaleType="centerCrop"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:srcCompat="@drawable/ic_assignment_turned_in_accent_24dp" />
+
+            <TextView
+                android:id="@+id/txtNewIdentityDoneMessage"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="16dp"
+                android:layout_marginRight="16dp"
+                android:layout_marginLeft="16dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:textAlignment="center"
+                android:text="@string/new_identity_done_message"
+                android:gravity="center"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/imgCreateIdentitySuccess"
+                app:layout_constraintWidth_max="500dp" />
+
+        </android.support.constraint.ConstraintLayout>
+
+    </ScrollView>
 
     <Button
         android:id="@+id/btnNewIdentityDoneExport"
@@ -42,5 +67,20 @@
         android:text="@string/button_new_identity_done_export"
         app:layout_constraintBottom_toTopOf="@+id/btnNewIdentityDone"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintWidth_max="500dp" />
+
+    <Button
+        android:id="@+id/btnNewIdentityDone"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="32dp"
+        android:text="@string/button_new_identity_done"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintWidth_max="500dp" />
+
 </android.support.constraint.ConstraintLayout>


### PR DESCRIPTION
**Description:**

Improve the layout of `NewIdentityDoneActivity`.

This is how the activity looks before the proposed changes:

<img src="https://user-images.githubusercontent.com/4005543/61699650-93736600-ad3b-11e9-93cc-c2cea7ff64f3.jpg" width="300">

... and here with the changes applied:

<img src="https://user-images.githubusercontent.com/4005543/61699680-a38b4580-ad3b-11e9-93cf-c495bbba667e.jpg" width="300">

