### PR TITLE
Fix crash bug related to srcCompat on old APIs

### DIFF
--- a/app/src/main/java/org/ea/sqrl/utils/SqrlApplication.java
+++ b/app/src/main/java/org/ea/sqrl/utils/SqrlApplication.java
@@ -8,6 +8,7 @@ import android.content.pm.ShortcutInfo;
 import android.content.pm.ShortcutManager;
 import android.graphics.drawable.Icon;
 import android.os.Build;
+import android.support.v7.app.AppCompatDelegate;
 import android.util.Log;
 
 import org.ea.sqrl.R;
@@ -35,6 +36,7 @@ public class SqrlApplication extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
+        AppCompatDelegate.setCompatVectorFromResourcesEnabled(true);
         configureShortcuts(getApplicationContext());
         setApplicationShortcuts(getApplicationContext());
         try {

--- a/app/src/main/res/layout-land/activity_login.xml
+++ b/app/src/main/res/layout-land/activity_login.xml
@@ -76,8 +76,7 @@
                 android:paddingTop="4dp"
                 android:paddingBottom="4dp"
                 android:scaleType="centerCrop"
-                android:src="@drawable/ic_keyboard_arrow_down_gray_24dp"
-                tools:srcCompat="@drawable/ic_keyboard_arrow_down_gray_24dp" />
+                app:srcCompat="@drawable/ic_keyboard_arrow_down_gray_24dp" />
 
             <TextView
                 android:id="@+id/txtAdvancedFunctions"
@@ -132,10 +131,9 @@
                 android:layout_marginTop="8dp"
                 android:padding="4dp"
                 android:scaleType="centerCrop"
-                android:src="@drawable/ic_info_outline_24dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="@+id/txtAlternateId"
-                tools:srcCompat="@drawable/ic_info_outline_24dp" />
+                app:srcCompat="@drawable/ic_info_outline_24dp" />
 
             <RadioGroup
                 android:id="@+id/radgrpAccountOptions"
@@ -185,10 +183,9 @@
                 android:layout_marginTop="32dp"
                 android:padding="4dp"
                 android:scaleType="centerCrop"
-                android:src="@drawable/ic_info_outline_24dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/txtAlternateId"
-                tools:srcCompat="@drawable/ic_info_outline_24dp" />
+                app:srcCompat="@drawable/ic_info_outline_24dp" />
 
             <ImageView
                 android:id="@+id/imgEnableAccountHelp"
@@ -197,10 +194,9 @@
                 android:layout_marginTop="0dp"
                 android:padding="4dp"
                 android:scaleType="centerCrop"
-                android:src="@drawable/ic_info_outline_24dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/imgDisableAccountHelp"
-                tools:srcCompat="@drawable/ic_info_outline_24dp" />
+                app:srcCompat="@drawable/ic_info_outline_24dp" />
 
             <ImageView
                 android:id="@+id/imgRemoveAccountHelp"
@@ -209,10 +205,9 @@
                 android:layout_marginTop="0dp"
                 android:padding="4dp"
                 android:scaleType="centerCrop"
-                android:src="@drawable/ic_info_outline_24dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/imgEnableAccountHelp"
-                tools:srcCompat="@drawable/ic_info_outline_24dp" />
+                app:srcCompat="@drawable/ic_info_outline_24dp" />
 
         </android.support.constraint.ConstraintLayout>
 

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -124,8 +124,7 @@
                 android:paddingTop="4dp"
                 android:paddingBottom="4dp"
                 android:scaleType="centerCrop"
-                android:src="@drawable/ic_keyboard_arrow_down_gray_24dp"
-                tools:srcCompat="@drawable/ic_keyboard_arrow_down_gray_24dp" />
+                app:srcCompat="@drawable/ic_keyboard_arrow_down_gray_24dp" />
 
             <TextView
                 android:id="@+id/txtAdvancedFunctions"
@@ -181,8 +180,7 @@
                 android:scaleType="centerCrop"
                 app:layout_constraintTop_toTopOf="@+id/txtAlternateId"
                 app:layout_constraintEnd_toEndOf="parent"
-                android:src="@drawable/ic_info_outline_24dp"
-                tools:srcCompat="@drawable/ic_info_outline_24dp" />
+                app:srcCompat="@drawable/ic_info_outline_24dp" />
 
             <RadioGroup
                 android:id="@+id/radgrpAccountOptions"
@@ -230,8 +228,7 @@
                 android:scaleType="centerCrop"
                 app:layout_constraintTop_toBottomOf="@+id/txtAlternateId"
                 app:layout_constraintEnd_toEndOf="parent"
-                android:src="@drawable/ic_info_outline_24dp"
-                tools:srcCompat="@drawable/ic_info_outline_24dp" />
+                app:srcCompat="@drawable/ic_info_outline_24dp" />
 
             <ImageView
                 android:id="@+id/imgEnableAccountHelp"
@@ -242,8 +239,7 @@
                 android:scaleType="centerCrop"
                 app:layout_constraintTop_toBottomOf="@+id/imgDisableAccountHelp"
                 app:layout_constraintEnd_toEndOf="parent"
-                android:src="@drawable/ic_info_outline_24dp"
-                tools:srcCompat="@drawable/ic_info_outline_24dp" />
+                app:srcCompat="@drawable/ic_info_outline_24dp" />
 
             <ImageView
                 android:id="@+id/imgRemoveAccountHelp"
@@ -254,8 +250,7 @@
                 android:scaleType="centerCrop"
                 app:layout_constraintTop_toBottomOf="@+id/imgEnableAccountHelp"
                 app:layout_constraintEnd_toEndOf="parent"
-                android:src="@drawable/ic_info_outline_24dp"
-                tools:srcCompat="@drawable/ic_info_outline_24dp" />
+                app:srcCompat="@drawable/ic_info_outline_24dp" />
 
         </android.support.constraint.ConstraintLayout>
 


### PR DESCRIPTION
**Description:**

Revised fix to https://github.com/alexhauser/secure-quick-reliable-login/pull/1
Fix crash bug related to srcCompat on old APIs.

Changes:
- Remove `android:src` and change `tools:srcCompat` to `app:srcCompat` on ImageViews in `LoginActivity`
- Add `AppCompatDelegate.setCompatVectorFromResourcesEnabled(true);` to onCreate of our Application class to correctly initialize the vector drawables support library

