### PR TITLE
Fix "Enable QuickPass" title

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -94,18 +94,6 @@
             android:label="@string/title_reset_password"
             />
 
-        <activity android:name=".activites.account.DisableAccountActivity"
-            android:label="@string/title_disable_account"
-            />
-
-        <activity android:name=".activites.account.EnableAccountActivity"
-            android:label="@string/title_enable_account"
-            />
-
-        <activity android:name=".activites.account.RemoveAccountActivity"
-            android:label="@string/title_remove_account"
-            />
-
         <activity android:name=".activites.identity.RenameActivity"
             android:label="@string/title_rename_identity"
             />
@@ -136,20 +124,12 @@
             -->
         </activity>
 
-        <activity android:name=".activites.account.AccountOptionsActivity"
-            android:label="@string/title_account_options"
-            />
-
         <activity android:name=".activites.CPSMissingActivity"
             android:label="@string/title_cps_missing"
             />
 
         <activity android:name=".activites.LanguageActivity"
             android:label="@string/title_language"
-            />
-
-        <activity android:name=".activites.account.AlternativeLoginActivity"
-            android:label="@string/title_alternative_identity"
             />
 
         <activity

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -180,7 +180,7 @@
             />
 
         <activity android:name=".activites.EnableQuickPassActivity"
-            android:label="@string/quickpass_enable_message"
+            android:label="@string/title_enable_quickpass"
             />
 
         <provider

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -263,7 +263,7 @@
 <string name="set_quickpass">Set QuickPass</string>
 <string name="set_quickpass_long">Enter SQRL password to engage QuickPass</string>
 <string name="identity_required">An identity must be created before using this function</string>
-<string name="quickpass_enable_heading">Enable QuickPass</string>
+<string name="title_enable_quickpass">Enable QuickPass</string>
 <string name="idle_timeout_guidance">So you don\'t forget your SQRL master password, the maximum QuickPass timeout is one week ( %1$s minutes), after which you\'ll have to type in the master password again.</string>
 <string name="guidance_heading">Guidance</string>
 <string name="button_identity_options">Identity options</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -263,7 +263,7 @@
 <string name="set_quickpass">Set QuickPass</string>
 <string name="set_quickpass_long">Enter SQRL password to engage QuickPass</string>
 <string name="identity_required">An identity must be created before using this function</string>
-<string name="quickpass_enable_heading">Enable QuickPass</string>
+<string name="title_enable_quickpass">Enable QuickPass</string>
 <string name="idle_timeout_guidance">So you don\'t forget your SQRL master password, the maximum QuickPass timeout is one week ( %1$s minutes), after which you\'ll have to type in the master password again.</string>
 <string name="guidance_heading">Guidance</string>
 <string name="button_identity_options">Identity options</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -263,7 +263,7 @@
 <string name="set_quickpass">Set QuickPass</string>
 <string name="set_quickpass_long">Enter SQRL password to engage QuickPass</string>
 <string name="identity_required">An identity must be created before using this function</string>
-<string name="quickpass_enable_heading">Enable QuickPass</string>
+<string name="title_enable_quickpass">Enable QuickPass</string>
 <string name="idle_timeout_guidance">So you don\'t forget your SQRL master password, the maximum QuickPass timeout is one week ( %1$s minutes), after which you\'ll have to type in the master password again.</string>
 <string name="guidance_heading">Guidance</string>
 <string name="button_identity_options">Identity options</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -263,7 +263,7 @@
 <string name="set_quickpass">QuickPass einrichten</string>
 <string name="set_quickpass_long">SQRL-Passwort eingeben, um QuickPass zu aktivieren</string>
 <string name="identity_required">Es muss eine Identität erstellt werden, bevor diese Funktion benützt werden kann</string>
-<string name="quickpass_enable_heading">QuickPass aktivieren</string>
+<string name="title_enable_quickpass">QuickPass aktivieren</string>
 <string name="idle_timeout_guidance">Damit Sie Ihr SQRL Masterpasswort nicht vergessen, kann QuickPass maximal eine Woche (%1$s Minuten) aktiv bleiben. Danach müssen Sie ihr Masterpasswort erneut eingeben.</string>
 <string name="guidance_heading">Anleitung</string>
 <string name="button_identity_options">Identitäts-Optionen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -263,7 +263,7 @@
 <string name="set_quickpass">Set QuickPass</string>
 <string name="set_quickpass_long">Enter SQRL password to engage QuickPass</string>
 <string name="identity_required">An identity must be created before using this function</string>
-<string name="quickpass_enable_heading">Enable QuickPass</string>
+<string name="title_enable_quickpass">Enable QuickPass</string>
 <string name="idle_timeout_guidance">So you don\'t forget your SQRL master password, the maximum QuickPass timeout is one week ( %1$s minutes), after which you\'ll have to type in the master password again.</string>
 <string name="guidance_heading">Guidance</string>
 <string name="button_identity_options">Opciones de identidad</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -263,7 +263,7 @@
 <string name="set_quickpass">Aseta QuickPass</string>
 <string name="set_quickpass_long">Syötä SQRL salasana aloittaaksesi QuickPassin käytön</string>
 <string name="identity_required">Identiteetti tulee luoda ennen tämän ominaisuuden käyttöä</string>
-<string name="quickpass_enable_heading">Aktivoi QuickPass</string>
+<string name="title_enable_quickpass">Aktivoi QuickPass</string>
 <string name="idle_timeout_guidance">Jottet unohda SQRL-salasanaasi, maksimi QuickPass käyttöaika on yksi viikko (%1$s minuuttia), jonka jälkeen pääsalasana tulee syöttää uudestaan.</string>
 <string name="guidance_heading">Opastus</string>
 <string name="button_identity_options">Identiteetin asetukset</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -263,7 +263,7 @@
 <string name="set_quickpass">Set QuickPass</string>
 <string name="set_quickpass_long">Enter SQRL password to engage QuickPass</string>
 <string name="identity_required">An identity must be created before using this function</string>
-<string name="quickpass_enable_heading">Enable QuickPass</string>
+<string name="title_enable_quickpass">Enable QuickPass</string>
 <string name="idle_timeout_guidance">So you don\'t forget your SQRL master password, the maximum QuickPass timeout is one week ( %1$s minutes), after which you\'ll have to type in the master password again.</string>
 <string name="guidance_heading">Guidance</string>
 <string name="button_identity_options">Identity options</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -263,7 +263,7 @@
 <string name="set_quickpass">Set QuickPass</string>
 <string name="set_quickpass_long">Enter SQRL password to engage QuickPass</string>
 <string name="identity_required">An identity must be created before using this function</string>
-<string name="quickpass_enable_heading">Enable QuickPass</string>
+<string name="title_enable_quickpass">Enable QuickPass</string>
 <string name="idle_timeout_guidance">So you don\'t forget your SQRL master password, the maximum QuickPass timeout is one week ( %1$s minutes), after which you\'ll have to type in the master password again.</string>
 <string name="guidance_heading">Guidance</string>
 <string name="button_identity_options">Identity options</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -263,7 +263,7 @@
 <string name="set_quickpass">क्विकपास सेट करें</string>
 <string name="set_quickpass_long">क्विकपास संलग्न करने के लिए SQRL पासवर्ड दर्ज करें</string>
 <string name="identity_required">इस फ़ंक्शन का उपयोग करने से पहले एक पहचान अवशय बनाई जानी चाहिए</string>
-<string name="quickpass_enable_heading">क्विकपास सक्षम करें</string>
+<string name="title_enable_quickpass">क्विकपास सक्षम करें</string>
 <string name="idle_timeout_guidance">इसलिए आप अपने SQRL मास्टर पासवर्ड को न भूलें, अधिकतम QuickPass टाइमआउट एक सप्ताह (%1$s मिनट) है, जिसके बाद आपको फिर से मास्टर पासवर्ड टाइप करना होगा।</string>
 <string name="guidance_heading">मार्गदर्शन</string>
 <string name="button_identity_options">पहचान विकल्प</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -263,7 +263,7 @@
 <string name="set_quickpass">Set QuickPass</string>
 <string name="set_quickpass_long">Enter SQRL password to engage QuickPass</string>
 <string name="identity_required">An identity must be created before using this function</string>
-<string name="quickpass_enable_heading">Enable QuickPass</string>
+<string name="title_enable_quickpass">Enable QuickPass</string>
 <string name="idle_timeout_guidance">So you don\'t forget your SQRL master password, the maximum QuickPass timeout is one week ( %1$s minutes), after which you\'ll have to type in the master password again.</string>
 <string name="guidance_heading">Guidance</string>
 <string name="button_identity_options">Identity options</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -263,7 +263,7 @@
 <string name="set_quickpass">Set QuickPass</string>
 <string name="set_quickpass_long">Enter SQRL password to engage QuickPass</string>
 <string name="identity_required">An identity must be created before using this function</string>
-<string name="quickpass_enable_heading">Enable QuickPass</string>
+<string name="title_enable_quickpass">Enable QuickPass</string>
 <string name="idle_timeout_guidance">So you don\'t forget your SQRL master password, the maximum QuickPass timeout is one week ( %1$s minutes), after which you\'ll have to type in the master password again.</string>
 <string name="guidance_heading">Guidance</string>
 <string name="button_identity_options">Identity options</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -263,7 +263,7 @@
 <string name="set_quickpass">Set QuickPass</string>
 <string name="set_quickpass_long">Enter SQRL password to engage QuickPass</string>
 <string name="identity_required">An identity must be created before using this function</string>
-<string name="quickpass_enable_heading">Enable QuickPass</string>
+<string name="title_enable_quickpass">Enable QuickPass</string>
 <string name="idle_timeout_guidance">So you don\'t forget your SQRL master password, the maximum QuickPass timeout is one week ( %1$s minutes), after which you\'ll have to type in the master password again.</string>
 <string name="guidance_heading">Guidance</string>
 <string name="button_identity_options">Identity options</string>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -263,7 +263,7 @@
 <string name="set_quickpass">Set QuickPass</string>
 <string name="set_quickpass_long">Enter SQRL password to engage QuickPass</string>
 <string name="identity_required">An identity must be created before using this function</string>
-<string name="quickpass_enable_heading">Enable QuickPass</string>
+<string name="title_enable_quickpass">Enable QuickPass</string>
 <string name="idle_timeout_guidance">So you don\'t forget your SQRL master password, the maximum QuickPass timeout is one week ( %1$s minutes), after which you\'ll have to type in the master password again.</string>
 <string name="guidance_heading">Guidance</string>
 <string name="button_identity_options">Identity options</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -263,7 +263,7 @@
 <string name="set_quickpass">Set QuickPass</string>
 <string name="set_quickpass_long">Enter SQRL password to engage QuickPass</string>
 <string name="identity_required">An identity must be created before using this function</string>
-<string name="quickpass_enable_heading">Enable QuickPass</string>
+<string name="title_enable_quickpass">Enable QuickPass</string>
 <string name="idle_timeout_guidance">So you don\'t forget your SQRL master password, the maximum QuickPass timeout is one week ( %1$s minutes), after which you\'ll have to type in the master password again.</string>
 <string name="guidance_heading">Guidance</string>
 <string name="button_identity_options">Identity options</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -263,7 +263,7 @@
 <string name="set_quickpass">Set QuickPass</string>
 <string name="set_quickpass_long">Enter SQRL password to engage QuickPass</string>
 <string name="identity_required">An identity must be created before using this function</string>
-<string name="quickpass_enable_heading">Enable QuickPass</string>
+<string name="title_enable_quickpass">Enable QuickPass</string>
 <string name="idle_timeout_guidance">So you don\'t forget your SQRL master password, the maximum QuickPass timeout is one week ( %1$s minutes), after which you\'ll have to type in the master password again.</string>
 <string name="guidance_heading">Guidance</string>
 <string name="button_identity_options">Identity options</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -263,7 +263,7 @@
 <string name="set_quickpass">Set QuickPass</string>
 <string name="set_quickpass_long">Enter SQRL password to engage QuickPass</string>
 <string name="identity_required">An identity must be created before using this function</string>
-<string name="quickpass_enable_heading">Enable QuickPass</string>
+<string name="title_enable_quickpass">Enable QuickPass</string>
 <string name="idle_timeout_guidance">So you don\'t forget your SQRL master password, the maximum QuickPass timeout is one week ( %1$s minutes), after which you\'ll have to type in the master password again.</string>
 <string name="guidance_heading">Guidance</string>
 <string name="button_identity_options">Identity options</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -263,7 +263,7 @@
 <string name="set_quickpass">Aktivera QuickPass</string>
 <string name="set_quickpass_long">Skriv in SQRL lösenord för att aktivera QuickPass</string>
 <string name="identity_required">En identitet måste vara skapad för att använda denna funktion</string>
-<string name="quickpass_enable_heading">Aktivera QuickPass</string>
+<string name="title_enable_quickpass">Aktivera QuickPass</string>
 <string name="idle_timeout_guidance">Så att du inte glömmer ditt SQRL huvud lösenord, har maximum tiden för QuickPass satts till en vecka ( %1$s minuter), efter detta behöver du skriva in huvud lösenordet igen.</string>
 <string name="guidance_heading">Vägledning</string>
 <string name="button_identity_options">Identitets hantering</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -263,7 +263,7 @@
 <string name="set_quickpass">Set QuickPass</string>
 <string name="set_quickpass_long">Enter SQRL password to engage QuickPass</string>
 <string name="identity_required">An identity must be created before using this function</string>
-<string name="quickpass_enable_heading">Enable QuickPass</string>
+<string name="title_enable_quickpass">Enable QuickPass</string>
 <string name="idle_timeout_guidance">So you don\'t forget your SQRL master password, the maximum QuickPass timeout is one week ( %1$s minutes), after which you\'ll have to type in the master password again.</string>
 <string name="guidance_heading">Guidance</string>
 <string name="button_identity_options">Identity options</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -263,7 +263,7 @@
 <string name="set_quickpass">Set QuickPass</string>
 <string name="set_quickpass_long">Enter SQRL password to engage QuickPass</string>
 <string name="identity_required">An identity must be created before using this function</string>
-<string name="quickpass_enable_heading">Enable QuickPass</string>
+<string name="title_enable_quickpass">Enable QuickPass</string>
 <string name="idle_timeout_guidance">So you don\'t forget your SQRL master password, the maximum QuickPass timeout is one week ( %1$s minutes), after which you\'ll have to type in the master password again.</string>
 <string name="guidance_heading">Guidance</string>
 <string name="button_identity_options">Identity options</string>


### PR DESCRIPTION
Issue #406

*Description:*

Fix the string name for the title of `EnableQuickPassActivity` as discussed in the above issue.

*Changes:*
- Change string name from `quickpass_enable_heading` to `title_enable_quickpass` for all languages. (@kalaspuffar , will you please handle this in POEditor? Thanks!)
- While working in the manifest, I found that there are still left-overs of deleted activities. I removed those.
