### PR TITLE
Improve naming of identities

### DIFF
--- a/app/src/main/java/org/ea/sqrl/activites/create/SaveIdentityActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/create/SaveIdentityActivity.java
@@ -78,8 +78,9 @@ public class SaveIdentityActivity extends LoginBaseActivity {
                     handler.post(() -> hideProgressPopup());
                 }
 
-                long newIdentityId = mDbHelper.newIdentity(storage.createSaveData());
-                mDbHelper.updateIdentityName(newIdentityId, txtIdentityName.getText().toString());
+                long newIdentityId = mDbHelper.newIdentity(SaveIdentityActivity.this, storage.createSaveData());
+                mDbHelper.updateIdentityName(SaveIdentityActivity.this, newIdentityId,
+                        txtIdentityName.getText().toString());
 
                 SqrlApplication.saveCurrentId(this.getApplication(), newIdentityId);
 

--- a/app/src/main/java/org/ea/sqrl/activites/identity/ImportActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/identity/ImportActivity.java
@@ -104,7 +104,8 @@ public class ImportActivity extends BaseActivity {
                     firstIdentity = true;
                 }
 
-                long newIdentityId = mDbHelper.newIdentity(storage.createSaveData());
+                long newIdentityId = mDbHelper.newIdentity(
+                        ImportActivity.this, storage.createSaveData());
 
                 SqrlApplication.saveCurrentId(this.getApplication(), newIdentityId);
 
@@ -114,7 +115,8 @@ public class ImportActivity extends BaseActivity {
 
                     if(newIdentityId != 0) {
                         if(firstIdentity) {
-                            mDbHelper.updateIdentityName(newIdentityId, "Default");
+                            mDbHelper.updateIdentityName(ImportActivity.this, newIdentityId,
+                                    getResources().getString(R.string.default_identity_name));
                             startActivity(new Intent(this, MainActivity.class));
                         } else {
                             startActivity(new Intent(this, RenameActivity.class));

--- a/app/src/main/java/org/ea/sqrl/activites/identity/RenameActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/identity/RenameActivity.java
@@ -49,7 +49,8 @@ public class RenameActivity extends BaseActivity {
         final long currentId = SqrlApplication.getCurrentId(this.getApplication());
 
         if(currentId != 0) {
-            mDbHelper.updateIdentityName(currentId, txtIdentityName.getText().toString());
+            mDbHelper.updateIdentityName(RenameActivity.this, currentId,
+                    txtIdentityName.getText().toString());
         }
 
         InputMethodManager imm = (InputMethodManager) getSystemService(this.INPUT_METHOD_SERVICE);

--- a/app/src/main/java/org/ea/sqrl/activites/identity/ResetPasswordActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/identity/ResetPasswordActivity.java
@@ -97,7 +97,8 @@ public class ResetPasswordActivity extends BaseActivity {
                     }
                     handler.post(() -> ResetPasswordActivity.this.finish());
                 } else {
-                    long newIdentityId = mDbHelper.newIdentity(storage.createSaveData());
+                    long newIdentityId = mDbHelper.newIdentity(
+                            ResetPasswordActivity.this, storage.createSaveData());
                     SqrlApplication.saveCurrentId(this.getApplication(), newIdentityId);
 
                     if(newIdentity) {

--- a/app/src/main/java/org/ea/sqrl/database/IdentityDBHelper.java
+++ b/app/src/main/java/org/ea/sqrl/database/IdentityDBHelper.java
@@ -7,6 +7,7 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 
+import org.ea.sqrl.R;
 import org.ea.sqrl.database.IdentityContract.IdentityEntry;
 
 import java.util.HashMap;
@@ -61,14 +62,19 @@ public class IdentityDBHelper extends SQLiteOpenHelper {
         onUpgrade(db, oldVersion, newVersion);
     }
 
-    public long newIdentity(byte[] data) {
+    public long newIdentity(Context context, byte[] data) {
         ContentValues values = new ContentValues();
         values.put(IdentityContract.IdentityEntry.COLUMN_NAME_DATA, data);
-        return this.getWritableDatabase().insert(
+        long id = this.getWritableDatabase().insert(
                     IdentityEntry.TABLE_NAME,
                     null,
                     values
                 );
+
+        updateIdentityName(context, id,
+                context.getResources().getString(R.string.default_identity_name));
+
+        return id;
     }
 
     public byte[] getIdentityData(long id) {
@@ -131,13 +137,17 @@ public class IdentityDBHelper extends SQLiteOpenHelper {
         return true;
     }
 
-    public void updateIdentityName(long id, String name) {
+    public void updateIdentityName(Context context, long id, String name) {
         SQLiteDatabase db = this.getWritableDatabase();
 
+        if (name == null || name.isEmpty()) {
+            name = context.getResources().getString(R.string.default_identity_name);
+        }
         String newName = name;
-        int i = 1;
+
+        int i = 2;
         while(!checkUnique(id, newName)) {
-            newName = name + " (" + i + ")";
+            newName = name + " " + i;
             i++;
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -295,4 +295,5 @@
 <string name="quickpass">QuickPass</string>
 <string name="helptext_quickpass_login">Please provide the short \"QuickPass\", which consists of the first few characters of your SQRL identity password.</string>
 <string name="helptext_password_login">Please provide the full-length SQRL identity password that you have chosen for this identity.</string>
+<string name="default_identity_name">My Identity</string>
 </resources>


### PR DESCRIPTION
Issue #405

**Description:**

Change the default naming of identities as discussed in the above issue. (*"My Identity"*, *"My Identity 2"* ...)

**Changes:**

- Add translatable string for the default identity name (*"My Identity"*)
- Update `IdentityDBHelper.updateIdentityName()` to use the new default name if an empty string or `null` is provided for the `name` argument
- Add a call to `updateIdentityName()` within `IdentityDBHelper.newIdentity()` to ensure that every identity has a default name associated upon creation. Until now, it was possible to have identities without names

**Further discussion:**

I will post a new issue to discuss how we could simplify naming upon creating a new identity.
//EDIT: Here we go: https://github.com/kalaspuffar/secure-quick-reliable-login/issues/414