### PR TITLE
Fix intro tab color in night mode

### DIFF
--- a/app/src/main/res/layout/activity_introduction.xml
+++ b/app/src/main/res/layout/activity_introduction.xml
@@ -14,10 +14,10 @@
         android:layout_alignParentBottom="true"
         app:layout_constraintTop_toTopOf="parent"
         app:tabGravity="center"
-        app:tabTextColor="@android:color/darker_gray"
+        app:tabTextColor="@color/intro_tab_text"
         app:tabIndicatorColor="@color/colorAccent"
         app:tabMode="scrollable"
-        app:tabSelectedTextColor="@android:color/black">
+        app:tabSelectedTextColor="@color/intro_tab_selected_text">
     </android.support.design.widget.TabLayout>
 
 

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -28,4 +28,7 @@
     <color name="main_screen_scan_button_text">@android:color/primary_text_dark</color>
     <color name="scan_qr_icon_magnifying_glass_bg">@color/colorAccent</color>
 
+    <color name="intro_tab_text">@android:color/darker_gray</color>
+    <color name="intro_tab_selected_text">@color/colorAccent</color>
+
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -28,4 +28,7 @@
     <color name="main_screen_scan_button_text">@android:color/primary_text_dark</color>
     <color name="scan_qr_icon_magnifying_glass_bg">@android:color/white</color>
 
+    <color name="intro_tab_text">@android:color/darker_gray</color>
+    <color name="intro_tab_selected_text">@android:color/black</color>
+
 </resources>


### PR DESCRIPTION
**Description:**

In night mode, the text color of the selected tab header in `IntroductionActivity` had a very low contrast (black on dark gray):

![tab_1](https://user-images.githubusercontent.com/4005543/62493200-d3712900-b7d0-11e9-955f-ef40e7056f63.jpg)

Changing it to `colorAccent` only for night mode looks mutch better:

![tab_2](https://user-images.githubusercontent.com/4005543/62493308-1206e380-b7d1-11e9-97c6-5b8e28d164f3.jpg)
