### PR TITLE
Simplify naming when creating a new identity

### DIFF
--- a/app/src/main/java/org/ea/sqrl/activites/create/SaveIdentityActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/create/SaveIdentityActivity.java
@@ -11,6 +11,7 @@ import android.widget.ImageView;
 
 import org.ea.sqrl.R;
 import org.ea.sqrl.activites.base.LoginBaseActivity;
+import org.ea.sqrl.activites.identity.RenameActivity;
 import org.ea.sqrl.processors.SQRLStorage;
 import org.ea.sqrl.utils.PasswordStrengthMeter;
 import org.ea.sqrl.utils.SqrlApplication;
@@ -21,6 +22,8 @@ import org.ea.sqrl.utils.SqrlApplication;
  */
 public class SaveIdentityActivity extends LoginBaseActivity {
     private static final String TAG = "SaveIdentityActivity";
+
+    private boolean firstIdentity = false;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -34,7 +37,6 @@ public class SaveIdentityActivity extends LoginBaseActivity {
 
         SQRLStorage storage = SQRLStorage.getInstance(SaveIdentityActivity.this.getApplicationContext());
 
-        final EditText txtIdentityName = findViewById(R.id.txtIdentityName);
         final EditText txtNewPassword = findViewById(R.id.txtNewPassword);
         final EditText txtRetypePassword = findViewById(R.id.txtRetypePassword);
         final ViewGroup pwStrengthMeter = findViewById(R.id.passwordStrengthMeter);
@@ -78,19 +80,29 @@ public class SaveIdentityActivity extends LoginBaseActivity {
                     handler.post(() -> hideProgressPopup());
                 }
 
-                long newIdentityId = mDbHelper.newIdentity(SaveIdentityActivity.this, storage.createSaveData());
-                mDbHelper.updateIdentityName(SaveIdentityActivity.this, newIdentityId,
-                        txtIdentityName.getText().toString());
+                if(!mDbHelper.hasIdentities()) {
+                    firstIdentity = true;
+                }
 
+                long newIdentityId = mDbHelper.newIdentity(SaveIdentityActivity.this, storage.createSaveData());
                 SqrlApplication.saveCurrentId(this.getApplication(), newIdentityId);
 
                 handler.post(() -> {
-                    txtIdentityName.setText("");
                     txtNewPassword.setText("");
                     txtRetypePassword.setText("");
 
                     SaveIdentityActivity.this.finish();
-                    startActivity(new Intent(this, NewIdentityDoneActivity.class));
+
+                    Intent nextActivity = null;
+
+                    if(firstIdentity) {
+                        nextActivity = new Intent(this, NewIdentityDoneActivity.class);
+                    } else {
+                        nextActivity = new Intent(this, RenameActivity.class);
+                        nextActivity.putExtra(SqrlApplication.EXTRA_NEXT_ACTIVITY, NewIdentityDoneActivity.class.getName());
+                    }
+
+                    startActivity(nextActivity);
                 });
             }).start();
         });

--- a/app/src/main/java/org/ea/sqrl/activites/identity/ImportActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/identity/ImportActivity.java
@@ -115,8 +115,6 @@ public class ImportActivity extends BaseActivity {
 
                     if(newIdentityId != 0) {
                         if(firstIdentity) {
-                            mDbHelper.updateIdentityName(ImportActivity.this, newIdentityId,
-                                    getResources().getString(R.string.default_identity_name));
                             startActivity(new Intent(this, MainActivity.class));
                         } else {
                             startActivity(new Intent(this, RenameActivity.class));

--- a/app/src/main/java/org/ea/sqrl/activites/identity/RenameActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/identity/RenameActivity.java
@@ -57,6 +57,18 @@ public class RenameActivity extends BaseActivity {
         imm.hideSoftInputFromWindow(txtIdentityName.getWindowToken(), 0);
 
         RenameActivity.this.finishAffinity();
-        startActivity(new Intent(this, MainActivity.class));
+
+        Intent nextActivity = new Intent(this, MainActivity.class);
+
+        if (getIntent().hasExtra(SqrlApplication.EXTRA_NEXT_ACTIVITY)) {
+            try {
+                String activityClassName = getIntent().getStringExtra(SqrlApplication.EXTRA_NEXT_ACTIVITY);
+                nextActivity = new Intent(this, Class.forName(activityClassName));
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+
+        startActivity(nextActivity);
     }
 }

--- a/app/src/main/java/org/ea/sqrl/utils/SqrlApplication.java
+++ b/app/src/main/java/org/ea/sqrl/utils/SqrlApplication.java
@@ -28,6 +28,7 @@ public class SqrlApplication extends Application {
     private static final String TAG = "SqrlApplication";
     public static final String APPS_PREFERENCES = "org.ea.sqrl.preferences";
     public static final String CURRENT_ID = "current_id";
+    public static String EXTRA_NEXT_ACTIVITY = "next_activity";
 
     static ShortcutInfo scanShortcut;
     static ShortcutInfo logonShortcut;

--- a/app/src/main/res/layout/activity_save_identity.xml
+++ b/app/src/main/res/layout/activity_save_identity.xml
@@ -17,25 +17,6 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content" >
 
-            <EditText
-                android:id="@+id/txtIdentityName"
-                android:layout_width="0dp"
-                android:layout_height="52dp"
-                android:layout_marginStart="16dp"
-                android:layout_marginLeft="16dp"
-                android:layout_marginTop="16dp"
-                android:layout_marginEnd="16dp"
-                android:layout_marginRight="16dp"
-                android:ems="10"
-                android:hint="@string/txt_identity_name_hint"
-                android:inputType="textPersonName"
-                android:nextFocusDown="@id/imgNewPasswordHelp"
-                android:nextFocusForward="@id/imgNewPasswordHelp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                android:importantForAutofill="no" />
-
             <TextView
                 android:id="@+id/txtNewPasswordHeadline"
                 android:layout_width="0dp"
@@ -49,7 +30,7 @@
                 android:textStyle="bold"
                 app:layout_constraintEnd_toStartOf="@+id/imgNewPasswordHelp"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/txtIdentityName" />
+                app:layout_constraintTop_toTopOf="parent" />
 
             <ImageView
                 android:id="@+id/imgNewPasswordHelp"
@@ -61,7 +42,7 @@
                 android:nextFocusDown="@id/txtNewPassword"
                 android:nextFocusForward="@id/txtNewPassword"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/txtIdentityName"
+                app:layout_constraintTop_toTopOf="parent"
                 app:srcCompat="@drawable/ic_info_outline_24dp" />
 
             <EditText


### PR DESCRIPTION
Issue #414.

**Description:**

When creating a new identity, don't ask for an identity name if it's the first identity. 
(In essence, duplicate the behaviour that we use on import)

**Changes:**
- Remove identity name field from `SaveIdentityActivity`
- Upon identity creation, if it is not the first identity, send the user to the `RenameActivity` after saving the identity. Using an intent extra, let `RenameActivity` know that it should launch `NewIdentityDoneActivity` after the renaming process instead of `MainActivity`.
