### PR TITLE
back arrow on common base

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,7 +31,6 @@
         <activity
             android:name=".activites.identity.IdentityManagementActivity"
             android:label="@string/title_identity_management"
-            android:parentActivityName=".activites.MainActivity"
             />
 
         <activity

--- a/app/src/main/java/org/ea/sqrl/activites/MainActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/MainActivity.java
@@ -20,6 +20,7 @@ import org.ea.sqrl.utils.SqrlApplication;
 import org.ea.sqrl.utils.Utils;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 /**
  *
@@ -36,6 +37,9 @@ public class MainActivity extends LoginBaseActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+
+        Objects.requireNonNull(getSupportActionBar()).setDisplayHomeAsUpEnabled(false);
+        Objects.requireNonNull(getSupportActionBar()).setDisplayShowHomeEnabled(false);
 
         rootView = findViewById(R.id.mainActivityView);
         communicationFlowHandler = CommunicationFlowHandler.getInstance(this, handler);

--- a/app/src/main/java/org/ea/sqrl/activites/StartActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/StartActivity.java
@@ -14,6 +14,8 @@ import org.ea.sqrl.activites.identity.ImportActivity;
 import org.ea.sqrl.activites.identity.ImportOptionsActivity;
 import org.ea.sqrl.activites.identity.TextImportActivity;
 
+import java.util.Objects;
+
 /**
  * Start activity should be a base for the user so we bring them into the application and they know
  * how to use it when installed and identities are added. So where we add some text for to inform
@@ -29,6 +31,9 @@ public class StartActivity extends BaseActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_start);
+
+        Objects.requireNonNull(getSupportActionBar()).setDisplayHomeAsUpEnabled(false);
+        Objects.requireNonNull(getSupportActionBar()).setDisplayShowHomeEnabled(false);
 
         final TextView txtWelcomeMessage = findViewById(R.id.txtWelcomeMessage);
         txtWelcomeMessage.setMovementMethod(LinkMovementMethod.getInstance());

--- a/app/src/main/java/org/ea/sqrl/activites/base/CommonBaseActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/base/CommonBaseActivity.java
@@ -10,6 +10,8 @@ import android.support.v7.app.AppCompatDelegate;
 import org.ea.sqrl.R;
 import org.ea.sqrl.utils.Utils;
 
+import java.util.Objects;
+
 /**
  * This activity is inherited by all other activities and provides common logic
  * such as language support.
@@ -23,6 +25,9 @@ public class CommonBaseActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        Objects.requireNonNull(getSupportActionBar()).setDisplayHomeAsUpEnabled(true);
+        Objects.requireNonNull(getSupportActionBar()).setDisplayShowHomeEnabled(true);
 
         AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_AUTO);
 
@@ -51,6 +56,12 @@ public class CommonBaseActivity extends AppCompatActivity {
             mCurrentLanguage = language;
             this.recreate();
         }
+    }
+
+    @Override
+    public boolean onSupportNavigateUp() {
+        onBackPressed();
+        return true;
     }
 
     protected void showInfoMessage(String title, String message, Runnable done) {

--- a/app/src/main/java/org/ea/sqrl/activites/identity/IdentityManagementActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/identity/IdentityManagementActivity.java
@@ -29,7 +29,6 @@ public class IdentityManagementActivity extends BaseActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_identity_management);
-        Objects.requireNonNull(getSupportActionBar()).setDisplayShowHomeEnabled(true);
 
         setupErrorPopupWindow(getLayoutInflater());
 


### PR DESCRIPTION
**Issue #419**

**Description:**
Configure `CommonBaseActivity` to have the back navigation in the action bar

**Changes:**
Changed settings for action bar.  Added implementation to call `onBackPressed()` when navigation activated.  Removed `parentActivityName` from identity management manifest item.

**Discussion:**
There's more ways to get this same result than the way this PR does it, but if this does what we want, it's pretty simple.  It seems that if various activities customized `onBackPressed()`, then this solution should honor those customizations (although I'm posting this without very much testing to validate those).  There were no other instances of `parentActivityName` associated with activities in the manifest, but that would also be an alternative way to approach this.

In cases like this, it would be helpful to have a diagram that showed all the linkages between activities and how they should operate, for example, in some cases, the previous activity makes no sense, so we must start from an earlier point.  But I'm not quite familiar enough with all of the use-cases to know which activities are of this specialized type. 

I did see a `Close` button, which could have been removed, but I didn't know if removal of that (and similar) was something we wanted to do, or if keeping the button would make it more clear for the users.
