### PR TITLE
Selective display of identity management in options menu

### DIFF
--- a/app/src/main/java/org/ea/sqrl/activites/base/BaseActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/base/BaseActivity.java
@@ -138,7 +138,9 @@ public class BaseActivity extends CommonBaseActivity {
             menu.findItem(R.id.action_language).setVisible(false);
         }
 
-        if (this instanceof IdentityManagementActivity) {
+        if (this instanceof MainActivity) {
+            menu.findItem(R.id.action_identity_management).setVisible(true);
+        } else {
             menu.findItem(R.id.action_identity_management).setVisible(false);
         }
 


### PR DESCRIPTION
***Issue #421***

***Description:***
Display options menu on `MainActivity` only.

***Changes:***
Altered visibility of `action_identity_management` options menu item to be gone from everywhere except the main  `MainActivity`

***Discussion:***
Almost all of the activities that extend `BaseActivity` (where the options menu is defined) are "downstream" in activity flow of `IdentityManagementActivity`, so don't have the need to navigate to identity management this way.  There might be a few non-downstream activities, such as `LoginBaseActivity` and `StartActivity` that, before this change had the ability to navigate to identity management, but it didn't seem to make sense to add those (but we could).
