### PR TITLE
Enable "one step back" in identity creation wizard

### DIFF
--- a/app/src/main/java/org/ea/sqrl/activites/create/CreateIdentityActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/create/CreateIdentityActivity.java
@@ -31,11 +31,8 @@ public class CreateIdentityActivity extends CommonBaseActivity {
         txtCreateIdentityMessage.setMovementMethod(LinkMovementMethod.getInstance());
 
         final Button btnCreateIdentityCreate = findViewById(R.id.btnCreateIdentityCreate);
-        btnCreateIdentityCreate.setOnClickListener(
-                v -> {
-                    this.finish();
-                    startActivity(new Intent(this, EntropyGatherActivity.class));
-                }
-        );
+        btnCreateIdentityCreate.setOnClickListener(v -> {
+            startActivity(new Intent(this, EntropyGatherActivity.class));
+        });
     }
 }

--- a/app/src/main/java/org/ea/sqrl/activites/create/EntropyGatherActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/create/EntropyGatherActivity.java
@@ -39,6 +39,11 @@ public class EntropyGatherActivity extends CommonBaseActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_entropy_gather);
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
 
         showPhoneStatePermission();
     }
@@ -52,7 +57,6 @@ public class EntropyGatherActivity extends CommonBaseActivity {
                 mCamera.release();
             }
             entropyHarvester.digestEntropy();
-            this.finish();
             startActivity(new Intent(this, RescueCodeShowActivity.class));
         });
 

--- a/app/src/main/java/org/ea/sqrl/activites/create/NewIdentityDoneActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/create/NewIdentityDoneActivity.java
@@ -60,9 +60,15 @@ public class NewIdentityDoneActivity extends LoginBaseActivity {
 
     @Override
     public void onBackPressed() {
-        NewIdentityDoneActivity.this.finishAffinity();
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            NewIdentityDoneActivity.this.finishAndRemoveTask();
+
+        if (isTaskRoot()) {
+            startActivity(new Intent(NewIdentityDoneActivity.this, MainActivity.class));
+            finish();
+        } else {
+            finishAffinity();
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                finishAndRemoveTask();
+            }
         }
     }
 }

--- a/app/src/main/java/org/ea/sqrl/activites/create/RescueCodeEnterActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/create/RescueCodeEnterActivity.java
@@ -35,7 +35,6 @@ public class RescueCodeEnterActivity extends CommonBaseActivity {
 
         btnRescueCodeEnterNext.setEnabled(false);
         btnRescueCodeEnterNext.setOnClickListener(v -> {
-            this.finish();
             startActivity(new Intent(this, SaveIdentityActivity.class));
         });
     }

--- a/app/src/main/java/org/ea/sqrl/activites/create/RescueCodeShowActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/create/RescueCodeShowActivity.java
@@ -58,7 +58,6 @@ public class RescueCodeShowActivity extends CommonBaseActivity {
         }
 
         findViewById(R.id.btnRescueCodeShowNext).setOnClickListener(v -> {
-            this.finish();
             startActivity(new Intent(this, RescueCodeEnterActivity.class));
         });
 

--- a/app/src/main/java/org/ea/sqrl/activites/create/SaveIdentityActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/create/SaveIdentityActivity.java
@@ -91,7 +91,7 @@ public class SaveIdentityActivity extends LoginBaseActivity {
                     txtNewPassword.setText("");
                     txtRetypePassword.setText("");
 
-                    SaveIdentityActivity.this.finish();
+                    SaveIdentityActivity.this.finishAffinity();
 
                     Intent nextActivity = null;
 

--- a/app/src/main/java/org/ea/sqrl/activites/identity/RenameActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/identity/RenameActivity.java
@@ -45,6 +45,18 @@ public class RenameActivity extends BaseActivity {
         findViewById(R.id.btnRename).setOnClickListener(v -> doRename());
     }
 
+    @Override
+    public void onBackPressed() {
+        hideKeyboard();
+
+        if (isTaskRoot()) {
+            startActivity(getNextActivity());
+            finish();
+        } else {
+            super.onBackPressed();
+        }
+    }
+
     private void doRename() {
         final long currentId = SqrlApplication.getCurrentId(this.getApplication());
 
@@ -53,11 +65,12 @@ public class RenameActivity extends BaseActivity {
                     txtIdentityName.getText().toString());
         }
 
-        InputMethodManager imm = (InputMethodManager) getSystemService(this.INPUT_METHOD_SERVICE);
-        imm.hideSoftInputFromWindow(txtIdentityName.getWindowToken(), 0);
-
+        hideKeyboard();
         RenameActivity.this.finishAffinity();
+        startActivity(getNextActivity());
+    }
 
+    private Intent getNextActivity() {
         Intent nextActivity = new Intent(this, MainActivity.class);
 
         if (getIntent().hasExtra(SqrlApplication.EXTRA_NEXT_ACTIVITY)) {
@@ -68,7 +81,11 @@ public class RenameActivity extends BaseActivity {
                 e.printStackTrace();
             }
         }
+        return nextActivity;
+    }
 
-        startActivity(nextActivity);
+    private void hideKeyboard() {
+        InputMethodManager imm = (InputMethodManager) getSystemService(INPUT_METHOD_SERVICE);
+        imm.hideSoftInputFromWindow(txtIdentityName.getWindowToken(), 0);
     }
 }


### PR DESCRIPTION
**Description:**

Enable going back one step at a time in identity creation wizard. 

This enables going back to double check the rescue code if the user notices in the next step that it was recorded incorrectly. The rescue code input will always start with a blank form though, to avoid a situation where the user would go back and forth to input the rescue code without recording it.

**Changes:**
- Don't immediately finish activities which are part of the "create identity" wizard. Finish all activities upon saving the identity though.
- Move `showPhoneStatePermission()` from `onCreate()` to `onResume()` in `EntropyGatherActivity` to also start gathering entropy when resuming the activity
- Fix the "back" behaviour of `RenameActivity` and `NewIdentitiyDoneActivity` so that the new functionality is taken into account