### PR TITLE
Fix identity show layout

### DIFF
--- a/app/src/main/res/layout-land/activity_show_identity.xml
+++ b/app/src/main/res/layout-land/activity_show_identity.xml
@@ -43,8 +43,8 @@
 
     <TextView
         android:id="@+id/txtIdentityText"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginLeft="16dp"
         android:layout_marginTop="8dp"
@@ -53,10 +53,12 @@
         android:layout_marginBottom="16dp"
         android:fontFamily="monospace"
         android:textSize="18sp"
+        android:text="TEXTUAL ID"
         app:layout_constraintBottom_toTopOf="@+id/btnCloseIdentity"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/guideline2"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        tools:ignore="HardcodedText" />
 
     <android.support.constraint.Guideline
         android:id="@+id/guideline2"

--- a/app/src/main/res/layout/activity_show_identity.xml
+++ b/app/src/main/res/layout/activity_show_identity.xml
@@ -43,7 +43,7 @@
 
     <TextView
         android:id="@+id/txtIdentityText"
-        android:layout_width="0dp"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginBottom="16dp"
         android:layout_marginEnd="16dp"
@@ -52,7 +52,9 @@
         android:layout_marginLeft="16dp"
         android:fontFamily="monospace"
         android:textSize="18sp"
+        android:text="TEXTUAL ID"
         app:layout_constraintBottom_toTopOf="@+id/btnCloseIdentity"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        tools:ignore="HardcodedText" />
 </android.support.constraint.ConstraintLayout>


### PR DESCRIPTION
Issue #427.

**Description:**
Fix the layout of the textual identity representation in `ShowIdentityActivity`.

**Changes:**
- Change with and height attributes of `txtIdentityText` from `0dp` to `wrap_content` in both landscape and portrait, so that the textual identity will display centered horizontally as well as vertically (while keeping the text left-aligned)
- Added dummy text to help design time visualization