### PR TITLE
Fix Alt-Id input field not recognizable

### DIFF
--- a/app/src/main/res/drawable/alt_id_input_background.xml
+++ b/app/src/main/res/drawable/alt_id_input_background.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <stroke android:width="1dp" android:color="@color/alt_id_input_border" />
+    <corners android:radius="8dip"/>
+    <padding android:left="0dip" android:top="0dip" android:right="0dip" android:bottom="0dip" />
+    <solid android:color="@color/alt_id_input_background"/>
+</shape>

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -175,48 +175,78 @@
             android:layout_marginStart="16dp"
             android:layout_marginRight="16dp"
             android:layout_marginLeft="16dp"
-            android:paddingLeft="24dp"
-            android:paddingStart="16dp"
+            android:paddingLeft="0dp"
+            android:paddingStart="0dp"
             android:paddingRight="0dp"
-            android:paddingEnd="16dp"
+            android:paddingEnd="0dp"
             android:paddingBottom="16dp"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/toggleAdvancedFunctionsLayout">
 
-            <EditText
-                android:id="@+id/txtAlternateId"
+            <android.support.constraint.ConstraintLayout
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginRight="16dp"
-                android:layout_marginEnd="16dp"
-                android:layout_marginTop="8dp"
-                android:hint="@string/button_alternative_identity"
-                android:inputType="text"
-                app:layout_constraintTop_toTopOf="parent"
+                android:id="@+id/altIdLayout"
+                android:background="@drawable/alt_id_input_background"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="8dp"
+                android:layout_marginStart="8dp"
+                android:layout_marginRight="8dp"
+                android:layout_marginLeft="8dp"
+                android:paddingLeft="8dp"
+                android:paddingStart="8dp"
+                android:paddingRight="0dp"
+                android:paddingEnd="0dp"
+                android:paddingBottom="0dp"
+                android:paddingTop="0dp"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toStartOf="@+id/imgAlternateIdHelp"
-                android:importantForAutofill="no" />
-
-            <ImageView
-                android:id="@+id/imgAlternateIdHelp"
-                android:layout_width="32dp"
-                android:layout_height="32dp"
-                android:layout_marginLeft="16dp"
-                android:layout_marginStart="16dp"
-                android:layout_marginTop="8dp"
-                android:padding="4dp"
-                android:scaleType="centerCrop"
-                app:layout_constraintTop_toTopOf="@+id/txtAlternateId"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:srcCompat="@drawable/ic_info_outline_24dp" />
+                app:layout_constraintTop_toTopOf="@+id/advancedFunctionsLayout">
+
+                <EditText
+                    android:id="@+id/txtAlternateId"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginRight="8dp"
+                    android:layout_marginEnd="8dp"
+                    android:layout_marginTop="0dp"
+                    android:layout_marginBottom="0dp"
+                    android:hint="@string/button_alternative_identity"
+                    android:inputType="text"
+                    android:textSize="14dp"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toStartOf="@+id/imgAlternateIdHelp"
+                    android:importantForAutofill="no" />
+
+                <ImageView
+                    android:id="@+id/imgAlternateIdHelp"
+                    android:layout_width="32dp"
+                    android:layout_height="32dp"
+                    android:layout_marginLeft="16dp"
+                    android:layout_marginStart="16dp"
+                    android:layout_marginEnd="8dp"
+                    android:layout_marginRight="8dp"
+                    android:layout_marginTop="4dp"
+                    android:padding="4dp"
+                    android:scaleType="centerCrop"
+                    app:layout_constraintTop_toTopOf="@+id/txtAlternateId"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:srcCompat="@drawable/ic_info_outline_24dp" />
+
+
+            </android.support.constraint.ConstraintLayout>
 
             <RadioGroup
                 android:id="@+id/radgrpAccountOptions"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
-                app:layout_constraintTop_toBottomOf="@id/txtAlternateId"
+                android:layout_marginTop="8dp"
+                android:layout_marginLeft="16dp"
+                android:layout_marginStart="16dp"
+                app:layout_constraintTop_toBottomOf="@id/altIdLayout"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toStartOf="@+id/imgDisableAccountHelp" >
 
@@ -253,9 +283,11 @@
                 android:layout_width="32dp"
                 android:layout_height="32dp"
                 android:layout_marginTop="32dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginRight="16dp"
                 android:padding="4dp"
                 android:scaleType="centerCrop"
-                app:layout_constraintTop_toBottomOf="@+id/txtAlternateId"
+                app:layout_constraintTop_toBottomOf="@+id/altIdLayout"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:srcCompat="@drawable/ic_info_outline_24dp" />
 
@@ -264,6 +296,8 @@
                 android:layout_width="32dp"
                 android:layout_height="32dp"
                 android:layout_marginTop="0dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginRight="16dp"
                 android:padding="4dp"
                 android:scaleType="centerCrop"
                 app:layout_constraintTop_toBottomOf="@+id/imgDisableAccountHelp"
@@ -275,6 +309,8 @@
                 android:layout_width="32dp"
                 android:layout_height="32dp"
                 android:layout_marginTop="0dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginRight="16dp"
                 android:padding="4dp"
                 android:scaleType="centerCrop"
                 app:layout_constraintTop_toBottomOf="@+id/imgEnableAccountHelp"

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -31,4 +31,7 @@
     <color name="intro_tab_text">@android:color/darker_gray</color>
     <color name="intro_tab_selected_text">@color/colorAccent</color>
 
+    <color name="alt_id_input_background">#77000000</color>
+    <color name="alt_id_input_border">@android:color/transparent</color>
+
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -31,4 +31,7 @@
     <color name="intro_tab_text">@android:color/darker_gray</color>
     <color name="intro_tab_selected_text">@android:color/black</color>
 
+    <color name="alt_id_input_background">@android:color/background_light</color>
+    <color name="alt_id_input_border">@android:color/transparent</color>
+
 </resources>


### PR DESCRIPTION
Issue #432.

**Description:**
This PR aims at fixing the issue of the Alt-Id input textfield not being recognizable or being mistaken for a headline for the radio button group below.

**Changes:**
Added a background color around the Alt-Id input text field and info icon to make it stand out as an input control.

This is how it looks now, I hope you all agree that this should solve the problem without overly bloating the layout:
(sorry for the German screenshots)

<img src="https://user-images.githubusercontent.com/4005543/64859918-dd861300-d62b-11e9-9227-a34be52c96a2.jpg">

And in dark mode:

<img src="https://user-images.githubusercontent.com/4005543/64859939-eecf1f80-d62b-11e9-8303-19e8773b390d.jpg">


