### PR TITLE
Improve rescue code printout page

### DIFF
--- a/app/src/main/java/org/ea/sqrl/services/IdentityPrintDocumentAdapter.java
+++ b/app/src/main/java/org/ea/sqrl/services/IdentityPrintDocumentAdapter.java
@@ -1,9 +1,7 @@
 package org.ea.sqrl.services;
 
 import android.app.Activity;
-import android.content.pm.PackageInfo;
 import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
@@ -28,8 +26,6 @@ import org.ea.sqrl.utils.Utils;
 
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 
 import io.nayuki.qrcodegen.QrCode;
 
@@ -206,33 +202,6 @@ public class IdentityPrintDocumentAdapter extends PrintDocumentAdapter {
         paint.setTypeface(Typeface.DEFAULT);
         drawBlockOfText(canvas, paint, activity.getString(R.string.print_identity_desc3), lastBlockY + (bodyText * 2) + (i * bodyText), bodyText);
 
-
-        StringBuilder versionString = new StringBuilder();
-        versionString.append(activity.getString(R.string.print_version_string));
-        versionString.append(" ");
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
-        versionString.append(sdf.format(new Date()));
-        versionString.append(" * ");
-        versionString.append("Version: ");
-
-        Bitmap loadLogo = BitmapFactory.decodeResource(activity.getResources(), R.drawable.sqrl_print_logo);
-        Bitmap sqrlLogo = Bitmap.createScaledBitmap(loadLogo, 40, 40, false);
-
-        canvas.drawBitmap(
-                sqrlLogo,
-                canvasMiddle - (sqrlLogo.getScaledWidth(canvas) / 2),
-                canvas.getHeight() - 140,
-                paint
-        );
-
-        try {
-            PackageInfo pInfo = activity.getPackageManager().getPackageInfo(activity.getPackageName(), 0);
-            versionString.append(pInfo.versionName);
-        } catch (Exception e) {
-            Log.e(TAG, e.getMessage(), e);
-        }
-
-        drawCenteredText(canvas, paint, versionString.toString(), canvas.getHeight() - 80, 10);
-        drawCenteredText(canvas, paint, "https://github.com/kalaspuffar/secure-quick-reliable-login", canvas.getHeight() - 65, 10);
+        Utils.drawPrintPageFooter(activity, canvas);
     }
 }

--- a/app/src/main/java/org/ea/sqrl/utils/Utils.java
+++ b/app/src/main/java/org/ea/sqrl/utils/Utils.java
@@ -4,18 +4,29 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.res.AssetManager;
 import android.content.res.Resources;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
 import android.net.Uri;
 import android.os.Build;
 import android.preference.PreferenceManager;
 import android.support.v7.widget.PopupMenu;
+import android.text.Layout;
+import android.text.StaticLayout;
+import android.text.TextPaint;
 import android.util.DisplayMetrics;
+import android.util.Log;
 import android.view.View;
 
 import com.google.zxing.FormatException;
 
+import org.ea.sqrl.R;
 import org.ea.sqrl.database.IdentityDBHelper;
 import org.ea.sqrl.processors.SQRLStorage;
 
@@ -24,6 +35,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.Locale;
 
 import static android.content.pm.PackageManager.GET_META_DATA;
@@ -190,5 +203,74 @@ public class Utils {
         if (getDisplayMetrics(activity).heightPixels < minHeight) {
             view.setVisibility(View.GONE);
         }
+    }
+
+    public static int drawTextBlock(Canvas canvas, String text, Layout.Alignment alignment, TextPaint textPaint, int y, int margin) {
+        int width = canvas.getWidth() - (margin * 2);
+
+        StaticLayout staticLayout = new StaticLayout(
+                text,
+                textPaint,
+                width,
+                alignment,
+                1,
+                0,
+                false);
+
+        canvas.save();
+        canvas.translate(margin, y);
+        staticLayout.draw(canvas);
+        canvas.restore();
+
+        return staticLayout.getHeight();
+    }
+
+    public static void drawPrintPageFooter(Activity activity, Canvas canvas) {
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+
+        StringBuilder versionString = new StringBuilder();
+        versionString.append(activity.getString(R.string.print_version_string));
+        versionString.append(" ");
+        versionString.append(sdf.format(new Date()));
+        versionString.append(" * ");
+        versionString.append("Version: ");
+
+        Bitmap loadLogo = BitmapFactory.decodeResource(activity.getResources(), R.drawable.sqrl_print_logo);
+        Bitmap sqrlLogo = Bitmap.createScaledBitmap(loadLogo, 40, 40, false);
+
+        TextPaint textPaint = new TextPaint();
+        textPaint.setAntiAlias(true);
+        textPaint.setTextSize(10);
+        textPaint.setFakeBoldText(false);
+        textPaint.setColor(Color.DKGRAY);
+
+        canvas.drawBitmap(
+                sqrlLogo,
+                (canvas.getWidth()/2) - (sqrlLogo.getScaledWidth(canvas) / 2),
+                canvas.getHeight() - 140,
+                new Paint()
+        );
+
+        try {
+            PackageInfo pInfo = activity.getPackageManager().getPackageInfo(activity.getPackageName(), 0);
+            versionString.append(pInfo.versionName);
+        } catch (Exception e) {
+            Log.e(TAG, e.getMessage(), e);
+        }
+
+        drawTextBlock(
+                canvas,
+                versionString.toString(),
+                Layout.Alignment.ALIGN_CENTER,
+                textPaint,
+                canvas.getHeight() - 80,
+                20);
+
+        drawTextBlock(canvas,
+                "https://github.com/kalaspuffar/secure-quick-reliable-login",
+                Layout.Alignment.ALIGN_CENTER,
+                textPaint,
+                canvas.getHeight() - 65,
+                20);
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -297,4 +297,7 @@
 <string name="title_enable_quickpass">Enable QuickPass</string>
 <string name="default_identity_name">My Identity</string>
 <string name="language_korean">Korean</string>
+<string name="rescue_code_page_headline">This is your Identity\'s Rescue Code</string>
+<string name="rescue_code_page_warning">Do not discard this page</string>
+<string name="rescue_code_page_description">This is the irreplaceable SQRL Rescue Code for the SQRL identity you are creating.\n\nThis code cannot be recreated and must not be lost, misplaced or destroyed. It will allow you to recover from any disaster that might occur. If your identity\'s password is forgotten, or if your SQRL identity should become compromised, this Rescue Code allows you to recover from any situation. (Some situations may also require your SQRL identity. So be sure to also keep a backup of your identity.)\n\nThis printout should be stored in a safe and secure place where it cannot be found by others, but CAN be retrieved if you should ever need it. That need may never arise. But if it does, you\'ll be glad that you kept it safe and secure.\n\nYour identity\'s Rescue Code is:</string>
 </resources>


### PR DESCRIPTION
Issue #438.

**Description:**
Improve the layout and UX of the page that is being created when a user prints the rescue code during the creation of a new identity.

This basically duplicates the layout and texts from GRC's reference client and adds an additional app-specific footer.

**Changes:**
- Add headline, warning and descriptive texts
- Add footer (logo and app info)
- Break drawing the footer layout out into a utility function `Utils.drawPrintPageFooter(...)` so that it can be reused by by all `PrintDocumentAdapter`s
- Add utility function `Utils.drawTextBlock(...)` to draw (multiline) text onto the canvas

![rescue_code_print](https://user-images.githubusercontent.com/4005543/65764925-1b546280-e127-11e9-8493-1faec6796bcc.jpg)

**Discussion:**

@kalaspuffar, I noticed that in `IdentityPrintDocumentAdapter` you created a custom text-wrapping functionality for drawing multi-line text blocks. My new utility function `Utils.drawTextBlock(...)`, which I use in `RescueCodePrintDocumentAdapter`, uses Android's stock `StaticLayout` functionality instead, which - at least in theory - should be more robust than any home-brewn solution. 

If we want to use my new approach in `IdentityPrintDocumentAdapter` as well, it could replace all the custom functionality of `drawBlockOfText(...)`, `findNextString(...)` as well as `drawCenteredText(...)`.

If you agree, I could easily port `IdentityPrintDocumentAdapter` over to the new `Utils.drawTextBlock(...)` in a follow-up PR.

Also, I'm interested in your opinion on whether it's ok to have those utility functions in our general `Utils` class or if you'd prefer having a dedicated class á la `DocumentPrintUtils` instead.

