### PR TITLE
PrintDocumentAdapter improvements

### DIFF
--- a/app/src/main/java/org/ea/sqrl/services/RescueCodePrintDocumentAdapter.java
+++ b/app/src/main/java/org/ea/sqrl/services/RescueCodePrintDocumentAdapter.java
@@ -19,7 +19,7 @@ import android.text.TextPaint;
 
 import org.ea.sqrl.R;
 import org.ea.sqrl.processors.SQRLStorage;
-import org.ea.sqrl.utils.Utils;
+import org.ea.sqrl.utils.DocumentPrintUtils;
 
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -119,7 +119,7 @@ public class RescueCodePrintDocumentAdapter extends PrintDocumentAdapter {
         String warning = "!! " + activity.getResources().getString(R.string.rescue_code_page_warning).toUpperCase() + " !!";
         String description = activity.getResources().getString(R.string.rescue_code_page_description);
 
-        lastBlockY += Utils.drawTextBlock(
+        lastBlockY += DocumentPrintUtils.drawTextBlock(
                 canvas,
                 headline,
                 Layout.Alignment.ALIGN_CENTER,
@@ -127,7 +127,7 @@ public class RescueCodePrintDocumentAdapter extends PrintDocumentAdapter {
                 lastBlockY,
                 marginLeft);
 
-        lastBlockY += Utils.drawTextBlock(
+        lastBlockY += DocumentPrintUtils.drawTextBlock(
                 canvas,
                 warning,
                 Layout.Alignment.ALIGN_CENTER,
@@ -135,7 +135,7 @@ public class RescueCodePrintDocumentAdapter extends PrintDocumentAdapter {
                 lastBlockY + 40,
                 marginLeft) + 40;
 
-        lastBlockY += Utils.drawTextBlock(
+        lastBlockY += DocumentPrintUtils.drawTextBlock(
                 canvas,
                 description,
                 Layout.Alignment.ALIGN_NORMAL,
@@ -153,7 +153,7 @@ public class RescueCodePrintDocumentAdapter extends PrintDocumentAdapter {
         }
         String rescueCodeOutput = sb.toString();
 
-        lastBlockY += Utils.drawTextBlock(
+        lastBlockY += DocumentPrintUtils.drawTextBlock(
                 canvas,
                 rescueCodeOutput,
                 Layout.Alignment.ALIGN_CENTER,
@@ -164,7 +164,7 @@ public class RescueCodePrintDocumentAdapter extends PrintDocumentAdapter {
         String idName = activity.getResources().getString(R.string.txt_identity_name_hint) +
                 ": __________________________________";
 
-        Utils.drawTextBlock(
+        DocumentPrintUtils.drawTextBlock(
                 canvas,
                 idName,
                 Layout.Alignment.ALIGN_CENTER,
@@ -172,6 +172,6 @@ public class RescueCodePrintDocumentAdapter extends PrintDocumentAdapter {
                 lastBlockY + 60,
                 marginLeft);
 
-        Utils.drawPrintPageFooter(activity, canvas);
+        DocumentPrintUtils.drawPrintPageFooter(activity, canvas);
     }
 }

--- a/app/src/main/java/org/ea/sqrl/utils/DocumentPrintUtils.java
+++ b/app/src/main/java/org/ea/sqrl/utils/DocumentPrintUtils.java
@@ -1,0 +1,96 @@
+package org.ea.sqrl.utils;
+
+import android.app.Activity;
+import android.content.pm.PackageInfo;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.text.Layout;
+import android.text.StaticLayout;
+import android.text.TextPaint;
+import android.util.Log;
+
+import org.ea.sqrl.R;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * This class hosts utility functions for drawing print documents.
+ *
+ * @author Alex Hauser
+ */
+public class DocumentPrintUtils {
+    private static final String TAG = "DocumentPrintUtils";
+
+    public static int drawTextBlock(Canvas canvas, String text, Layout.Alignment alignment, TextPaint textPaint, int y, int margin) {
+        int width = canvas.getWidth() - (margin * 2);
+
+        StaticLayout staticLayout = new StaticLayout(
+                text,
+                textPaint,
+                width,
+                alignment,
+                1,
+                0,
+                false);
+
+        canvas.save();
+        canvas.translate(margin, y);
+        staticLayout.draw(canvas);
+        canvas.restore();
+
+        return staticLayout.getHeight();
+    }
+
+    public static void drawPrintPageFooter(Activity activity, Canvas canvas) {
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+
+        StringBuilder versionString = new StringBuilder();
+        versionString.append(activity.getString(R.string.print_version_string));
+        versionString.append(" ");
+        versionString.append(sdf.format(new Date()));
+        versionString.append(" * ");
+        versionString.append("Version: ");
+
+        Bitmap loadLogo = BitmapFactory.decodeResource(activity.getResources(), R.drawable.sqrl_print_logo);
+        Bitmap sqrlLogo = Bitmap.createScaledBitmap(loadLogo, 40, 40, false);
+
+        TextPaint textPaint = new TextPaint();
+        textPaint.setAntiAlias(true);
+        textPaint.setTextSize(10);
+        textPaint.setFakeBoldText(false);
+        textPaint.setColor(Color.DKGRAY);
+
+        canvas.drawBitmap(
+                sqrlLogo,
+                (canvas.getWidth()/2) - (sqrlLogo.getScaledWidth(canvas) / 2),
+                canvas.getHeight() - 140,
+                new Paint()
+        );
+
+        try {
+            PackageInfo pInfo = activity.getPackageManager().getPackageInfo(activity.getPackageName(), 0);
+            versionString.append(pInfo.versionName);
+        } catch (Exception e) {
+            Log.e(TAG, e.getMessage(), e);
+        }
+
+        drawTextBlock(
+                canvas,
+                versionString.toString(),
+                Layout.Alignment.ALIGN_CENTER,
+                textPaint,
+                canvas.getHeight() - 80,
+                20);
+
+        drawTextBlock(canvas,
+                "https://github.com/kalaspuffar/secure-quick-reliable-login",
+                Layout.Alignment.ALIGN_CENTER,
+                textPaint,
+                canvas.getHeight() - 65,
+                20);
+    }
+}

--- a/app/src/main/java/org/ea/sqrl/utils/Utils.java
+++ b/app/src/main/java/org/ea/sqrl/utils/Utils.java
@@ -4,29 +4,18 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.res.AssetManager;
 import android.content.res.Resources;
-import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
-import android.graphics.Canvas;
-import android.graphics.Color;
-import android.graphics.Paint;
 import android.net.Uri;
 import android.os.Build;
 import android.preference.PreferenceManager;
 import android.support.v7.widget.PopupMenu;
-import android.text.Layout;
-import android.text.StaticLayout;
-import android.text.TextPaint;
 import android.util.DisplayMetrics;
-import android.util.Log;
 import android.view.View;
 
 import com.google.zxing.FormatException;
 
-import org.ea.sqrl.R;
 import org.ea.sqrl.database.IdentityDBHelper;
 import org.ea.sqrl.processors.SQRLStorage;
 
@@ -35,8 +24,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.Locale;
 
 import static android.content.pm.PackageManager.GET_META_DATA;
@@ -203,74 +190,5 @@ public class Utils {
         if (getDisplayMetrics(activity).heightPixels < minHeight) {
             view.setVisibility(View.GONE);
         }
-    }
-
-    public static int drawTextBlock(Canvas canvas, String text, Layout.Alignment alignment, TextPaint textPaint, int y, int margin) {
-        int width = canvas.getWidth() - (margin * 2);
-
-        StaticLayout staticLayout = new StaticLayout(
-                text,
-                textPaint,
-                width,
-                alignment,
-                1,
-                0,
-                false);
-
-        canvas.save();
-        canvas.translate(margin, y);
-        staticLayout.draw(canvas);
-        canvas.restore();
-
-        return staticLayout.getHeight();
-    }
-
-    public static void drawPrintPageFooter(Activity activity, Canvas canvas) {
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
-
-        StringBuilder versionString = new StringBuilder();
-        versionString.append(activity.getString(R.string.print_version_string));
-        versionString.append(" ");
-        versionString.append(sdf.format(new Date()));
-        versionString.append(" * ");
-        versionString.append("Version: ");
-
-        Bitmap loadLogo = BitmapFactory.decodeResource(activity.getResources(), R.drawable.sqrl_print_logo);
-        Bitmap sqrlLogo = Bitmap.createScaledBitmap(loadLogo, 40, 40, false);
-
-        TextPaint textPaint = new TextPaint();
-        textPaint.setAntiAlias(true);
-        textPaint.setTextSize(10);
-        textPaint.setFakeBoldText(false);
-        textPaint.setColor(Color.DKGRAY);
-
-        canvas.drawBitmap(
-                sqrlLogo,
-                (canvas.getWidth()/2) - (sqrlLogo.getScaledWidth(canvas) / 2),
-                canvas.getHeight() - 140,
-                new Paint()
-        );
-
-        try {
-            PackageInfo pInfo = activity.getPackageManager().getPackageInfo(activity.getPackageName(), 0);
-            versionString.append(pInfo.versionName);
-        } catch (Exception e) {
-            Log.e(TAG, e.getMessage(), e);
-        }
-
-        drawTextBlock(
-                canvas,
-                versionString.toString(),
-                Layout.Alignment.ALIGN_CENTER,
-                textPaint,
-                canvas.getHeight() - 80,
-                20);
-
-        drawTextBlock(canvas,
-                "https://github.com/kalaspuffar/secure-quick-reliable-login",
-                Layout.Alignment.ALIGN_CENTER,
-                textPaint,
-                canvas.getHeight() - 65,
-                20);
     }
 }


### PR DESCRIPTION
Followup to issue #439.

**Description:**

This is the discussed followup-PR that ports the improvements of the rescue code printout to the identity printout.

**Changes:**

- Move utility functions to a dedicated class called `DocumentPrintUtils`
- Port `IdentityPrintDocumentAdapter` to the new `drawTextBlock(...)` utility function
- Remove legacy code for drawing multiline text blocks, including helper functions
