### PR TITLE
Fix zero-padding in base56 decode

### DIFF
--- a/app/src/main/java/org/ea/sqrl/utils/EncryptionUtils.java
+++ b/app/src/main/java/org/ea/sqrl/utils/EncryptionUtils.java
@@ -42,7 +42,7 @@ public class EncryptionUtils {
      * @param data  input data stream.
      * @return      reversed byte stream
      */
-    private static byte[] reverse(byte[] data) {
+    public static byte[] reverse(byte[] data) {
         for(int i = 0; i < data.length / 2; i++) {
             byte temp = data[i];
             data[i] = data[data.length - i - 1];
@@ -142,6 +142,10 @@ public class EncryptionUtils {
         largeBytes = reverse(largeBytes);
         if(largeBytes.length > expectedNumberOfBytes) {
             largeBytes = Arrays.copyOfRange(largeBytes, 0, expectedNumberOfBytes);
+        } else if (largeBytes.length < expectedNumberOfBytes) {
+            byte[] temp = new byte[expectedNumberOfBytes];
+            System.arraycopy(largeBytes, 0, temp, 0, largeBytes.length);
+            largeBytes = temp;
         }
 
         return largeBytes;


### PR DESCRIPTION
Issue #449.

**Description:**
Add missing zero-padding in `EncryptionUtils.decodeBase56()`.
This should make the new base56 unit tests pass.

**Notes:**
Changing `EncryptionUtils.reverse()` to public just mirrors the changes in PR #450 to avoid merge conflicts.
