### PR TITLE
Fix EnHash regression

### DIFF
--- a/app/src/main/java/org/ea/sqrl/utils/EncryptionUtils.java
+++ b/app/src/main/java/org/ea/sqrl/utils/EncryptionUtils.java
@@ -249,7 +249,7 @@ public class EncryptionUtils {
             bytesToHash = digest.digest(bytesToHash);
             byte[] xorKey = Arrays.copyOf(bytesToHash, bytesToHash.length);
 
-            for(int i=0; i<16; i++) {
+            for(int i=0; i<15; i++) {
                 bytesToHash = digest.digest(bytesToHash);
                 xorKey = xor(xorKey, bytesToHash);
             }


### PR DESCRIPTION
Issue #452.

**Description:**
Fix a regression where the number of hash iterations within `EncryptionUtils.enHash()` was increased by one, causing the function to produce incorrect results.

Increasing the iteration count from 15 to 16 within the for-loop was unnecessary, since the first iteration is already done outside the loop.