### PR TITLE
Add EnHash unit test

### DIFF
--- a/app/src/test/java/org/ea/sqrl/EnHashUnitTest.java
+++ b/app/src/test/java/org/ea/sqrl/EnHashUnitTest.java
@@ -1,0 +1,29 @@
+package org.ea.sqrl;
+
+import org.ea.sqrl.utils.EncryptionUtils;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertArrayEquals;
+
+public class EnHashUnitTest {
+    @Test
+    public void testEnHashVectors() throws Exception {
+        List<List<String>> vectors = TestHelper.parseVectorCsvFile(
+                "enhash-vectors.txt", true, true );
+
+        int vectorNumber = 1;
+        for (List<String> vector: vectors) {
+            byte[] input = TestHelper.base64UrlDecode(vector.get(0));
+            byte[] expectedResult = TestHelper.base64UrlDecode(vector.get(1));
+
+            byte[] result = EncryptionUtils.enHash(input);
+
+            assertArrayEquals("testEnHashVectors / vector # " + vectorNumber +
+                    ": Decoded result should match result in vector file", expectedResult, result);
+
+            vectorNumber++;
+        }
+    }
+}

--- a/app/src/test/java/org/ea/sqrl/TestHelper.java
+++ b/app/src/test/java/org/ea/sqrl/TestHelper.java
@@ -7,6 +7,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
+import java.util.Base64;
 
 /**
  * A utility class providing common functionality for the project's
@@ -51,8 +52,8 @@ public class TestHelper {
                         field = field.substring(0, field.length()-1);
                     }
 
-                    if (removeQuotes) {
-                        if (field.charAt(0) == '"') field = field.substring(1, field.length()-1);
+                    if (removeQuotes && field.length() > 0) {
+                        if (field.charAt(0) == '"') field = field.substring(1);
                         if (field.charAt(field.length()-1) == '"') field = field.substring(0, field.length()-1);
                     }
                 }
@@ -66,5 +67,15 @@ public class TestHelper {
         s.close();
 
         return result;
+    }
+
+    static byte[] base64UrlDecode(String s) {
+
+        return Base64.getUrlDecoder().decode(s);
+    }
+
+    static String base64UrlEncode(byte[] input) {
+
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(input);
     }
 }


### PR DESCRIPTION
Issue #448.

**Description:**
Add unit test for EnHash vectors.

**Note:**
Adding the base64 helpers to the `TestHelper` class was necessary because we use the Android base64 implementation which is not available in the local unit tests. 
