### PR TITLE
Fix QuickPass Timeout bug

### DIFF
--- a/app/src/main/java/org/ea/sqrl/activites/base/BaseActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/base/BaseActivity.java
@@ -421,7 +421,7 @@ public class BaseActivity extends CommonBaseActivity {
     }
 
     public void clearQuickPassAfterTimeout() {
-        long delayMillis = SQRLStorage.getInstance(BaseActivity.this.getApplicationContext()).getIdleTimeout() * 60000;
+        long delayMillis = (long)SQRLStorage.getInstance(BaseActivity.this.getApplicationContext()).getIdleTimeout() * 60000l;
 
         SqrlApplication.setApplicationShortcuts(getApplicationContext());
 


### PR DESCRIPTION
Issue #461.

**Description:**
This fixes an integer overflow bug in `BaseActivity.clearQuickPassAfterTimeout()` which could cause negative _QuickPass Timeout_ values, effectively disabling QuickPass when large timeout values were used.
