### PR TITLE
Fix "App crashes on non-SQRL QC codes"

### DIFF
--- a/app/src/main/java/org/ea/sqrl/activites/MainActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/MainActivity.java
@@ -94,12 +94,12 @@ public class MainActivity extends LoginBaseActivity {
                 try {
                     qrCodeData = Utils.readSQRLQRCode(data);
                 } catch (FormatException fe) {
-                    showErrorMessage(R.string.scan_incorrect);
+                    Snackbar.make(rootView, R.string.scan_incorrect, Snackbar.LENGTH_LONG).show();
                     return;
                 }
 
                 if (qrCodeData == null) {
-                    showErrorMessage(R.string.scan_incorrect);
+                    Snackbar.make(rootView, R.string.scan_incorrect, Snackbar.LENGTH_LONG).show();
                     return;
                 }
 
@@ -117,8 +117,15 @@ public class MainActivity extends LoginBaseActivity {
                 }
 
                 final String serverData = new String(qrCodeData);
+                Uri serverUri = Uri.parse(serverData);
+
+                if (!Utils.isValidSqrlUri(serverUri)) {
+                    Snackbar.make(rootView, R.string.scan_incorrect, Snackbar.LENGTH_LONG).show();
+                    return;
+                }
+
                 Intent urlLoginIntent = new Intent(Intent.ACTION_VIEW);
-                urlLoginIntent.setData(Uri.parse(serverData));
+                urlLoginIntent.setData(serverUri);
                 urlLoginIntent.putExtra(LoginActivity.EXTRA_USE_CPS, false);
                 if (ACTION_QUICK_SCAN.equals(getIntent().getAction())) urlLoginIntent.putExtra(LoginActivity.EXTRA_QUICK_SCAN, true);
                 startActivity(urlLoginIntent);

--- a/app/src/main/java/org/ea/sqrl/utils/Utils.java
+++ b/app/src/main/java/org/ea/sqrl/utils/Utils.java
@@ -203,4 +203,12 @@ public class Utils {
         }
         return true;
     }
+
+    public static boolean isValidSqrlUri(Uri uri) {
+        if (uri == null) return false;
+        String scheme = uri.getScheme();
+        if (scheme == null || !scheme.toLowerCase().equals("sqrl")) return false;
+
+        return true;
+    }
 }


### PR DESCRIPTION
Issue #467 .

**Description:** 
This fixes the "_App crashes on non-SQRL QC codes_" bug which was reported in the forums at https://sqrl.grc.com/threads/problem-with-dummy-qr-code.1097/.

**Changes:**
- Added validity check for the scanned qr code data using the new utility function `Utils.isValidSqrlUri()`.
- Changed error messages from popup messages to toast messages, since the error popups seemed too arcane and invasive for such a mundane error condition.
