### PR TITLE
Enable "show password" on ChangePasswordActivity

### DIFF
--- a/app/src/main/java/org/ea/sqrl/activites/identity/ChangePasswordActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/identity/ChangePasswordActivity.java
@@ -33,9 +33,9 @@ public class ChangePasswordActivity extends BaseActivity {
         findViewById(R.id.btnDoChangePassword).setOnClickListener(v -> {
             if(!txtNewPassword.getText().toString().equals(txtRetypePassword.getText().toString())) {
                 showErrorMessage(R.string.change_password_retyped_password_do_not_match);
-                txtCurrentPassword.setText("");
                 txtNewPassword.setText("");
                 txtRetypePassword.setText("");
+                txtNewPassword.requestFocus();
                 return;
             }
 
@@ -49,15 +49,13 @@ public class ChangePasswordActivity extends BaseActivity {
                     handler.post(() -> {
                         hideProgressPopup();
                         txtCurrentPassword.setText("");
-                        txtNewPassword.setText("");
-                        txtRetypePassword.setText("");
+                        txtCurrentPassword.requestFocus();
                     });
                     storage.clearQuickPass();
                     storage.clear();
 
                     return;
                 }
-                clearQuickPassAfterTimeout();
 
                 boolean encryptStatus = storage.encryptIdentityKey(txtNewPassword.getText().toString(), entropyHarvester);
                 if (!encryptStatus) {
@@ -72,6 +70,7 @@ public class ChangePasswordActivity extends BaseActivity {
                     return;
                 }
 
+                storage.clearQuickPass();
                 storage.clear();
 
                 long currentId = SqrlApplication.getCurrentId(this.getApplication());

--- a/app/src/main/res/layout/activity_change_password.xml
+++ b/app/src/main/res/layout/activity_change_password.xml
@@ -6,6 +6,98 @@
     android:id="@+id/changePasswordActivityView"
     tools:context="org.ea.sqrl.activites.identity.ChangePasswordActivity">
 
+    <android.support.design.widget.TextInputLayout
+        android:id="@+id/txtCurrentPasswordLayout"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginRight="16dp"
+        android:layout_marginLeft="16dp"
+        android:layout_marginTop="16dp"
+        android:minWidth="400dp"
+        app:passwordToggleEnabled="true"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.504"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <android.support.design.widget.TextInputEditText
+            android:id="@+id/txtCurrentPassword"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/change_password_current"
+            android:nextFocusDown="@+id/txtNewPassword"
+            android:inputType="textPassword"
+            android:importantForAutofill="yes"
+            android:autofillHints="password"
+            android:focusedByDefault="true"/>
+    </android.support.design.widget.TextInputLayout>
+
+    <android.support.design.widget.TextInputLayout
+        android:id="@+id/txtNewPasswordLayout"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginRight="16dp"
+        android:layout_marginLeft="16dp"
+        android:layout_marginTop="8dp"
+        android:minWidth="400dp"
+        app:passwordToggleEnabled="true"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.504"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/txtCurrentPasswordLayout">
+
+        <android.support.design.widget.TextInputEditText
+            android:id="@+id/txtNewPassword"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:nextFocusDown="@+id/txtRetypePassword"
+            android:hint="@string/change_password_new_password"
+            android:inputType="textPassword"
+            android:importantForAutofill="no"/>
+    </android.support.design.widget.TextInputLayout>
+
+    <android.support.design.widget.TextInputLayout
+        android:id="@+id/txtRetypePasswordLayout"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginRight="16dp"
+        android:layout_marginLeft="16dp"
+        android:layout_marginTop="0dp"
+        android:minWidth="400dp"
+        app:passwordToggleEnabled="true"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/txtNewPasswordLayout">
+
+        <android.support.design.widget.TextInputEditText
+            android:id="@+id/txtRetypePassword"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:nextFocusDown="@+id/btnDoChangePassword"
+            android:hint="@string/change_password_retype"
+            android:inputType="textPassword"
+            android:importantForAutofill="no"/>
+    </android.support.design.widget.TextInputLayout>
+
+    <include layout="@layout/password_strength_meter"
+        android:id="@+id/passwordStrengthMeter"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginRight="16dp"
+        android:layout_marginLeft="16dp"
+        android:layout_marginTop="8dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/txtRetypePasswordLayout" />
+
     <Button
         android:id="@+id/btnDoChangePassword"
         android:layout_width="0dp"
@@ -19,71 +111,5 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
-
-    <EditText
-        android:id="@+id/txtCurrentPassword"
-        android:layout_width="0dp"
-        android:layout_height="48dp"
-        android:layout_marginEnd="16dp"
-        android:layout_marginStart="16dp"
-        android:layout_marginRight="16dp"
-        android:layout_marginLeft="16dp"
-        android:layout_marginTop="16dp"
-        android:ems="10"
-        android:hint="@string/change_password_current"
-        android:inputType="textPassword"
-        android:nextFocusDown="@+id/txtNewPassword"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.504"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-    <EditText
-        android:id="@+id/txtRetypePassword"
-        android:layout_width="0dp"
-        android:layout_height="48dp"
-        android:layout_marginEnd="16dp"
-        android:layout_marginStart="16dp"
-        android:layout_marginRight="16dp"
-        android:layout_marginLeft="16dp"
-        android:layout_marginTop="0dp"
-        android:ems="10"
-        android:hint="@string/change_password_retype"
-        android:inputType="textPassword"
-        android:nextFocusDown="@+id/btnDoChangePassword"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/txtNewPassword" />
-
-    <EditText
-        android:id="@+id/txtNewPassword"
-        android:layout_width="0dp"
-        android:layout_height="48dp"
-        android:layout_marginEnd="16dp"
-        android:layout_marginStart="16dp"
-        android:layout_marginRight="16dp"
-        android:layout_marginLeft="16dp"
-        android:layout_marginTop="8dp"
-        android:ems="10"
-        android:hint="@string/change_password_new_password"
-        android:inputType="textPassword"
-        android:nextFocusDown="@+id/txtRetypePassword"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.504"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/txtCurrentPassword" />
-
-    <include layout="@layout/password_strength_meter"
-        android:id="@+id/passwordStrengthMeter"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="16dp"
-        android:layout_marginStart="16dp"
-        android:layout_marginRight="16dp"
-        android:layout_marginLeft="16dp"
-        android:layout_marginTop="8dp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/txtRetypePassword" />
 
 </android.support.constraint.ConstraintLayout>


### PR DESCRIPTION
Closes issue #476 

**Description:**
Enable the "show password" toggle on all password fields within `ChangePasswordActivity` to enable un-masking entered passwords. This should make it easier for users to get their password entries right.

**Changes:**
 - Replace all `EditText` instances with `TextInputLayout` and set `app:passwordToggleEnabled="true"` on them
 - Clear QuickPass on successful password change, since leaving it active would cause the next QuickPass-enabled login to fail.
 - Some small optimizations in error situations (e.g. don't just blindly empty all password fields, but only those that actually caused the error)
