### PR TITLE
Re-mask passwords when submitting

### DIFF
--- a/app/src/main/java/org/ea/sqrl/activites/LoginActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/LoginActivity.java
@@ -7,6 +7,7 @@ import android.os.Build;
 import android.os.CancellationSignal;
 import android.os.Bundle;
 import android.support.constraint.ConstraintLayout;
+import android.support.design.widget.TextInputLayout;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.util.Log;
@@ -28,6 +29,7 @@ import org.ea.sqrl.processors.SQRLStorage;
 import org.ea.sqrl.utils.IdentitySelector;
 import org.ea.sqrl.utils.RescueCodeInputHelper;
 import org.ea.sqrl.utils.SqrlApplication;
+import org.ea.sqrl.utils.Utils;
 
 import java.security.KeyStore;
 import java.util.regex.Matcher;
@@ -45,6 +47,7 @@ public class LoginActivity extends LoginBaseActivity {
     public static final String ACTION_QUICKPASS_OPERATION = "org.ea.sqrl.activites.LOGON";
 
     private boolean useCps = true;
+    private TextInputLayout pwdTextInputLayout;
     private EditText txtLoginPassword;
     private IdentitySelector mIdentitySelector = null;
     private Matcher mSqrlMatcher;
@@ -56,6 +59,7 @@ public class LoginActivity extends LoginBaseActivity {
         setContentView(R.layout.activity_login);
 
         rootView = findViewById(R.id.loginActivityView);
+        pwdTextInputLayout = findViewById(R.id.txtLoginPasswordLayoutInternal);
         txtLoginPassword = findViewById(R.id.txtLoginPassword);
         communicationFlowHandler = CommunicationFlowHandler.getInstance(this, handler);
 
@@ -352,6 +356,8 @@ public class LoginActivity extends LoginBaseActivity {
 
         long currentId = SqrlApplication.getCurrentId(this.getApplication());
         if(currentId <= 0) return;
+
+        Utils.reMaskPassword(pwdTextInputLayout);
 
         String alternateId = ((TextView)findViewById(R.id.txtAlternateId)).getText().toString();
         if (!alternateId.equals("")) {

--- a/app/src/main/java/org/ea/sqrl/activites/identity/IdentitySettingsActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/identity/IdentitySettingsActivity.java
@@ -1,6 +1,7 @@
 package org.ea.sqrl.activites.identity;
 
 import android.os.Bundle;
+import android.support.design.widget.TextInputLayout;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.view.Gravity;
@@ -186,6 +187,7 @@ public class IdentitySettingsActivity extends BaseActivity implements TextWatche
         savePopupWindow.setTouchable(true);
         savePopupWindow.setFocusable(true);
 
+        final TextInputLayout pwdTextInputLayout = popupView.findViewById(R.id.txtPasswordLayout);
         final EditText txtPassword = popupView.findViewById(R.id.txtPassword);
 
         SQRLStorage storage = SQRLStorage.getInstance(IdentitySettingsActivity.this.getApplicationContext());
@@ -194,6 +196,7 @@ public class IdentitySettingsActivity extends BaseActivity implements TextWatche
         final Button btnSaveSettings = popupView.findViewById(R.id.btnSaveSettings);
         btnSaveSettings.setOnClickListener(v -> new Thread(() -> {
             handler.post(() -> {
+                Utils.reMaskPassword(pwdTextInputLayout);
                 savePopupWindow.dismiss();
                 showProgressPopup();
             });

--- a/app/src/main/java/org/ea/sqrl/activites/identity/ResetPasswordActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/identity/ResetPasswordActivity.java
@@ -2,6 +2,7 @@ package org.ea.sqrl.activites.identity;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.design.widget.TextInputLayout;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
@@ -15,6 +16,7 @@ import org.ea.sqrl.processors.SQRLStorage;
 import org.ea.sqrl.utils.PasswordStrengthMeter;
 import org.ea.sqrl.utils.RescueCodeInputHelper;
 import org.ea.sqrl.utils.SqrlApplication;
+import org.ea.sqrl.utils.Utils;
 
 public class ResetPasswordActivity extends BaseActivity {
 
@@ -28,6 +30,7 @@ public class ResetPasswordActivity extends BaseActivity {
         setupProgressPopupWindow(getLayoutInflater());
         setupErrorPopupWindow(getLayoutInflater());
 
+        final TextInputLayout newPwdTextInputLayout = findViewById(R.id.txtResetPasswordNewPasswordLayout);
         final EditText txtResetPasswordNewPassword = findViewById(R.id.txtResetPasswordNewPassword);
         final TextView txtResetPasswordDescription = findViewById(R.id.txtResetPasswordDescription);
         final ViewGroup pwStrengthMeter = findViewById(R.id.passwordStrengthMeter);
@@ -60,6 +63,7 @@ public class ResetPasswordActivity extends BaseActivity {
 
             SQRLStorage storage = SQRLStorage.getInstance(ResetPasswordActivity.this.getApplicationContext());
 
+            Utils.reMaskPassword(newPwdTextInputLayout);
             showProgressPopup();
 
             new Thread(() -> {

--- a/app/src/main/java/org/ea/sqrl/utils/Utils.java
+++ b/app/src/main/java/org/ea/sqrl/utils/Utils.java
@@ -11,12 +11,15 @@ import android.graphics.Color;
 import android.net.Uri;
 import android.os.Build;
 import android.preference.PreferenceManager;
+import android.support.design.widget.TextInputLayout;
 import android.support.v7.widget.PopupMenu;
 import android.text.Spannable;
 import android.text.SpannableString;
+import android.text.method.PasswordTransformationMethod;
 import android.text.style.ForegroundColorSpan;
 import android.util.DisplayMetrics;
 import android.view.View;
+import android.widget.EditText;
 
 import com.google.zxing.FormatException;
 
@@ -230,5 +233,17 @@ public class Utils {
             highlighted += 2;
         }
         return textSpan;
+    }
+
+    /**
+     * Re-masks the password field within a TextInputLayout if the password is currently visible in plain text.
+     * 
+     * @param textInputLayout The TextInputLayout holding the password field to be re-masked.
+     */
+    public static void reMaskPassword(TextInputLayout textInputLayout) {
+        EditText editText = (textInputLayout != null) ? textInputLayout.getEditText() : null;
+        if (editText != null && !(editText.getTransformationMethod() instanceof PasswordTransformationMethod)) {
+            textInputLayout.passwordVisibilityToggleRequested(true);
+        }
     }
 }

--- a/app/src/main/res/layout/activity_reset_password.xml
+++ b/app/src/main/res/layout/activity_reset_password.xml
@@ -55,7 +55,8 @@
             android:layout_height="wrap_content"
             android:nextFocusDown="@+id/btnResetPassword"
             android:hint="@string/reset_password_new"
-            android:inputType="textPassword"/>
+            android:inputType="textPassword"
+            android:importantForAutofill="no"/>
     </android.support.design.widget.TextInputLayout>
 
     <include layout="@layout/password_strength_meter"

--- a/app/src/main/res/layout/fragment_save_settings.xml
+++ b/app/src/main/res/layout/fragment_save_settings.xml
@@ -89,7 +89,9 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:hint="@string/save_settings_password"
-                android:inputType="textPassword"/>
+                android:inputType="textPassword"
+                android:importantForAutofill="yes"
+                android:autofillHints="password"/>
         </android.support.design.widget.TextInputLayout>
 
     </android.support.constraint.ConstraintLayout>


### PR DESCRIPTION
Fixes issue #474.

**Description:**

This PR will re-mask passwords upon form submission in case the user has chosen to display them in plain text while entering. 

This was implemented for the following activities:

 - `LoginActivity`
 - `IdentitySettingsActivity`
 - `ResetPasswordActivity`

**Notes**:

Once PR #478 is merged, we should probably backport this to `ChangePasswordActivity` as well.
Also, while I was working at the layout files, I've added a few small autofill optimizations along the way to start addressing issue #475.
