### PR TITLE
Reload identity onResume

### DIFF
--- a/app/src/main/java/org/ea/sqrl/activites/identity/IdentityManagementActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/identity/IdentityManagementActivity.java
@@ -11,6 +11,7 @@ import org.ea.sqrl.activites.base.BaseActivity;
 import org.ea.sqrl.activites.create.CreateIdentityActivity;
 
 import org.ea.sqrl.utils.IdentitySelector;
+import org.ea.sqrl.utils.SqrlApplication;
 import org.ea.sqrl.utils.Utils;
 
 import java.util.Objects;
@@ -57,6 +58,8 @@ public class IdentityManagementActivity extends BaseActivity {
         if(!mDbHelper.hasIdentities()) {
             IdentityManagementActivity.this.finish();
         } else {
+            long id = SqrlApplication.getCurrentId(this.getApplication());
+            SqrlApplication.setCurrentId(this.getApplicationContext(), id);
             mIdentitySelector.update();
         }
     }

--- a/app/src/main/java/org/ea/sqrl/activites/identity/IdentityManagementActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/identity/IdentityManagementActivity.java
@@ -58,6 +58,9 @@ public class IdentityManagementActivity extends BaseActivity {
         if(!mDbHelper.hasIdentities()) {
             IdentityManagementActivity.this.finish();
         } else {
+            // Here we are reloading the SQRL Identity that is indicated by the current contextual
+            // ID just in case a user has cancelled the identity creation process. We plan to
+            // refactor this at some point in the future with something more elegant.
             long id = SqrlApplication.getCurrentId(this.getApplication());
             SqrlApplication.setCurrentId(this.getApplicationContext(), id);
             mIdentitySelector.update();


### PR DESCRIPTION
Issue https://github.com/kalaspuffar/secure-quick-reliable-login/issues/487

Description:
Forces a reload of the identity data on resume of identity management after create identity

Changes:
Loads the current identity ID from context and does a full reload of the identity data through the SqrlApplication class
