### PR TITLE
Added QR decoder

### DIFF
--- a/app/src/main/java/org/ea/sqrl/activites/MainActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/MainActivity.java
@@ -9,6 +9,7 @@ import android.util.Log;
 import com.google.zxing.FormatException;
 import com.google.zxing.integration.android.IntentIntegrator;
 import com.google.zxing.integration.android.IntentResult;
+import org.ea.sqrl.utils.QRCodeDecodeHelper;
 
 import org.ea.sqrl.R;
 import org.ea.sqrl.activites.base.LoginBaseActivity;
@@ -92,7 +93,7 @@ public class MainActivity extends LoginBaseActivity {
                 byte[] qrCodeData = null;
 
                 try {
-                    qrCodeData = Utils.readSQRLQRCode(data);
+                    qrCodeData = QRCodeDecodeHelper.decode(result.getRawBytes());
                 } catch (FormatException fe) {
                     Snackbar.make(rootView, R.string.scan_incorrect, Snackbar.LENGTH_LONG).show();
                     return;

--- a/app/src/main/java/org/ea/sqrl/activites/identity/ImportActivity.java
+++ b/app/src/main/java/org/ea/sqrl/activites/identity/ImportActivity.java
@@ -14,6 +14,7 @@ import android.widget.TextView;
 
 import com.google.zxing.integration.android.IntentIntegrator;
 import com.google.zxing.integration.android.IntentResult;
+import org.ea.sqrl.utils.QRCodeDecodeHelper;
 
 import org.ea.sqrl.R;
 import org.ea.sqrl.activites.MainActivity;
@@ -145,7 +146,7 @@ public class ImportActivity extends BaseActivity {
                 ImportActivity.this.finish();
             } else {
                 try {
-                    byte[] qrCodeData = Utils.readSQRLQRCode(data);
+                    byte[] qrCodeData = QRCodeDecodeHelper.decode(result.getRawBytes());
                     if(qrCodeData.length == 0) {
                         showErrorMessage(R.string.scan_incorrect);
                         return;

--- a/app/src/main/java/org/ea/sqrl/utils/QRCodeDecodeHelper.java
+++ b/app/src/main/java/org/ea/sqrl/utils/QRCodeDecodeHelper.java
@@ -1,0 +1,16 @@
+package org.ea.sqrl.utils;
+
+import com.google.zxing.FormatException;
+import com.google.zxing.common.DecoderResult;
+import com.google.zxing.qrcode.decoder.Version;
+
+public class QRCodeDecodeHelper {
+    public static byte[] decode(byte[] bytes) throws FormatException {
+        DecoderResult dr = QRCodeDecodedBitStreamParser.decode(bytes, Version.getVersionForNumber(1), null, null);
+        byte[] qrCode = new byte[0];
+        for(byte[] newSegment : dr.getByteSegments()) {
+            qrCode = EncryptionUtils.combine(qrCode, newSegment);
+        }
+        return qrCode;
+    }
+}

--- a/app/src/main/java/org/ea/sqrl/utils/QRCodeDecodedBitStreamParser.java
+++ b/app/src/main/java/org/ea/sqrl/utils/QRCodeDecodedBitStreamParser.java
@@ -1,0 +1,386 @@
+/*
+ * Copyright 2007 ZXing authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ea.sqrl.utils;
+
+import com.google.zxing.DecodeHintType;
+import com.google.zxing.FormatException;
+import com.google.zxing.common.BitSource;
+import com.google.zxing.common.CharacterSetECI;
+import com.google.zxing.common.DecoderResult;
+import com.google.zxing.common.StringUtils;
+import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel;
+import com.google.zxing.qrcode.decoder.Mode;
+import com.google.zxing.qrcode.decoder.Version;
+
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * <p>QR Codes can encode text as bits in one of several modes, and can use multiple modes
+ * in one QR Code. This class decodes the bits back into text.</p>
+ *
+ * <p>See ISO 18004:2006, 6.4.3 - 6.4.7</p>
+ *
+ * @author Sean Owen
+ *
+ * Sliglty modified by Daniel Persson to add the alpha numeric and numeric streams to bytestreams.
+ */
+final class QRCodeDecodedBitStreamParser {
+
+    /**
+     * See ISO 18004:2006, 6.4.4 Table 5
+     */
+    private static final char[] ALPHANUMERIC_CHARS =
+            "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ $%*+-./:".toCharArray();
+    private static final int GB2312_SUBSET = 1;
+
+    private QRCodeDecodedBitStreamParser() {
+    }
+
+    static DecoderResult decode(byte[] bytes,
+                                Version version,
+                                ErrorCorrectionLevel ecLevel,
+                                Map<DecodeHintType,?> hints) throws FormatException {
+        BitSource bits = new BitSource(bytes);
+        StringBuilder result = new StringBuilder(50);
+        List<byte[]> byteSegments = new ArrayList<>(1);
+        int symbolSequence = -1;
+        int parityData = -1;
+
+        try {
+            CharacterSetECI currentCharacterSetECI = null;
+            boolean fc1InEffect = false;
+            Mode mode;
+            do {
+                // While still another segment to read...
+                if (bits.available() < 4) {
+                    // OK, assume we're done. Really, a TERMINATOR mode should have been recorded here
+                    mode = Mode.TERMINATOR;
+                } else {
+                    mode = Mode.forBits(bits.readBits(4)); // mode is encoded by 4 bits
+                }
+                if (mode != Mode.TERMINATOR) {
+                    if (mode == Mode.FNC1_FIRST_POSITION || mode == Mode.FNC1_SECOND_POSITION) {
+                        // We do little with FNC1 except alter the parsed result a bit according to the spec
+                        fc1InEffect = true;
+                    } else if (mode == Mode.STRUCTURED_APPEND) {
+                        if (bits.available() < 16) {
+                            throw FormatException.getFormatInstance();
+                        }
+                        // sequence number and parity is added later to the result metadata
+                        // Read next 8 bits (symbol sequence #) and 8 bits (parity data), then continue
+                        symbolSequence = bits.readBits(8);
+                        parityData = bits.readBits(8);
+                    } else if (mode == Mode.ECI) {
+                        // Count doesn't apply to ECI
+                        int value = parseECIValue(bits);
+                        currentCharacterSetECI = CharacterSetECI.getCharacterSetECIByValue(value);
+                        if (currentCharacterSetECI == null) {
+                            throw FormatException.getFormatInstance();
+                        }
+                    } else {
+                        // First handle Hanzi mode which does not start with character count
+                        if (mode == Mode.HANZI) {
+                            //chinese mode contains a sub set indicator right after mode indicator
+                            int subset = bits.readBits(4);
+                            int countHanzi = bits.readBits(mode.getCharacterCountBits(version));
+                            if (subset == GB2312_SUBSET) {
+                                decodeHanziSegment(bits, result, countHanzi);
+                            }
+                        } else {
+                            // "Normal" QR code modes:
+                            // How many characters will follow, encoded in this mode?
+                            int count = bits.readBits(mode.getCharacterCountBits(version));
+                            if (mode == Mode.NUMERIC) {
+                                decodeNumericSegment(bits, result, count, byteSegments);
+                            } else if (mode == Mode.ALPHANUMERIC) {
+                                decodeAlphanumericSegment(bits, result, count, fc1InEffect, byteSegments);
+                            } else if (mode == Mode.BYTE) {
+                                decodeByteSegment(bits, result, count, currentCharacterSetECI, byteSegments, hints);
+                            } else if (mode == Mode.KANJI) {
+                                decodeKanjiSegment(bits, result, count);
+                            } else {
+                                throw FormatException.getFormatInstance();
+                            }
+                        }
+                    }
+                }
+            } while (mode != Mode.TERMINATOR);
+        } catch (IllegalArgumentException iae) {
+            // from readBits() calls
+            throw FormatException.getFormatInstance();
+        }
+
+        return new DecoderResult(bytes,
+                result.toString(),
+                byteSegments.isEmpty() ? null : byteSegments,
+                ecLevel == null ? null : ecLevel.toString(),
+                symbolSequence,
+                parityData);
+    }
+
+    /**
+     * See specification GBT 18284-2000
+     */
+    private static void decodeHanziSegment(BitSource bits,
+                                           StringBuilder result,
+                                           int count) throws FormatException {
+        // Don't crash trying to read more bits than we have available.
+        if (count * 13 > bits.available()) {
+            throw FormatException.getFormatInstance();
+        }
+
+        // Each character will require 2 bytes. Read the characters as 2-byte pairs
+        // and decode as GB2312 afterwards
+        byte[] buffer = new byte[2 * count];
+        int offset = 0;
+        while (count > 0) {
+            // Each 13 bits encodes a 2-byte character
+            int twoBytes = bits.readBits(13);
+            int assembledTwoBytes = ((twoBytes / 0x060) << 8) | (twoBytes % 0x060);
+            if (assembledTwoBytes < 0x003BF) {
+                // In the 0xA1A1 to 0xAAFE range
+                assembledTwoBytes += 0x0A1A1;
+            } else {
+                // In the 0xB0A1 to 0xFAFE range
+                assembledTwoBytes += 0x0A6A1;
+            }
+            buffer[offset] = (byte) ((assembledTwoBytes >> 8) & 0xFF);
+            buffer[offset + 1] = (byte) (assembledTwoBytes & 0xFF);
+            offset += 2;
+            count--;
+        }
+
+        try {
+            result.append(new String(buffer, StringUtils.GB2312));
+        } catch (UnsupportedEncodingException ignored) {
+            throw FormatException.getFormatInstance();
+        }
+    }
+
+    private static void decodeKanjiSegment(BitSource bits,
+                                           StringBuilder result,
+                                           int count) throws FormatException {
+        // Don't crash trying to read more bits than we have available.
+        if (count * 13 > bits.available()) {
+            throw FormatException.getFormatInstance();
+        }
+
+        // Each character will require 2 bytes. Read the characters as 2-byte pairs
+        // and decode as Shift_JIS afterwards
+        byte[] buffer = new byte[2 * count];
+        int offset = 0;
+        while (count > 0) {
+            // Each 13 bits encodes a 2-byte character
+            int twoBytes = bits.readBits(13);
+            int assembledTwoBytes = ((twoBytes / 0x0C0) << 8) | (twoBytes % 0x0C0);
+            if (assembledTwoBytes < 0x01F00) {
+                // In the 0x8140 to 0x9FFC range
+                assembledTwoBytes += 0x08140;
+            } else {
+                // In the 0xE040 to 0xEBBF range
+                assembledTwoBytes += 0x0C140;
+            }
+            buffer[offset] = (byte) (assembledTwoBytes >> 8);
+            buffer[offset + 1] = (byte) assembledTwoBytes;
+            offset += 2;
+            count--;
+        }
+        // Shift_JIS may not be supported in some environments:
+        try {
+            result.append(new String(buffer, StringUtils.SHIFT_JIS));
+        } catch (UnsupportedEncodingException ignored) {
+            throw FormatException.getFormatInstance();
+        }
+    }
+
+    private static void decodeByteSegment(BitSource bits,
+                                          StringBuilder result,
+                                          int count,
+                                          CharacterSetECI currentCharacterSetECI,
+                                          Collection<byte[]> byteSegments,
+                                          Map<DecodeHintType,?> hints) throws FormatException {
+        // Don't crash trying to read more bits than we have available.
+        if (8 * count > bits.available()) {
+            throw FormatException.getFormatInstance();
+        }
+
+        byte[] readBytes = new byte[count];
+        for (int i = 0; i < count; i++) {
+            readBytes[i] = (byte) bits.readBits(8);
+        }
+        String encoding;
+        if (currentCharacterSetECI == null) {
+            // The spec isn't clear on this mode; see
+            // section 6.4.5: t does not say which encoding to assuming
+            // upon decoding. I have seen ISO-8859-1 used as well as
+            // Shift_JIS -- without anything like an ECI designator to
+            // give a hint.
+            encoding = StringUtils.guessEncoding(readBytes, hints);
+        } else {
+            encoding = currentCharacterSetECI.name();
+        }
+        try {
+            result.append(new String(readBytes, encoding));
+        } catch (UnsupportedEncodingException ignored) {
+            throw FormatException.getFormatInstance();
+        }
+        byteSegments.add(readBytes);
+    }
+
+    private static char toAlphaNumericChar(int value) throws FormatException {
+        if (value >= ALPHANUMERIC_CHARS.length) {
+            throw FormatException.getFormatInstance();
+        }
+        return ALPHANUMERIC_CHARS[value];
+    }
+
+    private static void decodeAlphanumericSegment(BitSource bits,
+                                                  StringBuilder result,
+                                                  int count,
+                                                  boolean fc1InEffect, List<byte[]> byteSegments) throws FormatException {
+        byte[] byteSegment = new byte[count];
+        int byteCounter = 0;
+
+        // Read two characters at a time
+        int start = result.length();
+        while (count > 1) {
+            if (bits.available() < 11) {
+                throw FormatException.getFormatInstance();
+            }
+            int nextTwoCharsBits = bits.readBits(11);
+
+            byteSegment[byteCounter++] = (byte)toAlphaNumericChar(nextTwoCharsBits / 45);
+            byteSegment[byteCounter++] = (byte)toAlphaNumericChar(nextTwoCharsBits % 45);
+
+            result.append(toAlphaNumericChar(nextTwoCharsBits / 45));
+            result.append(toAlphaNumericChar(nextTwoCharsBits % 45));
+            count -= 2;
+        }
+        if (count == 1) {
+            // special case: one character left
+            if (bits.available() < 6) {
+                throw FormatException.getFormatInstance();
+            }
+            int digitBits = bits.readBits(6);
+            byteSegment[byteCounter++] = (byte)toAlphaNumericChar(digitBits);
+            result.append(toAlphaNumericChar(digitBits));
+        }
+        // See section 6.4.8.1, 6.4.8.2
+        if (fc1InEffect) {
+            // We need to massage the result a bit if in an FNC1 mode:
+            for (int i = start; i < result.length(); i++) {
+                if (result.charAt(i) == '%') {
+                    if (i < result.length() - 1 && result.charAt(i + 1) == '%') {
+                        // %% is rendered as %
+                        result.deleteCharAt(i + 1);
+                        byteSegment = removeByte(byteSegment, i + 1);
+                    } else {
+                        // In alpha mode, % should be converted to FNC1 separator 0x1D
+                        result.setCharAt(i, (char) 0x1D);
+                        byteSegment[i] = 0x1D;
+                    }
+                }
+            }
+        }
+        byteSegments.add(byteSegment);
+    }
+
+    private static byte[] removeByte(byte[] bytes, int idx) {
+        byte[] res = new byte[bytes.length - 1];
+        System.arraycopy(bytes, 0, res, 0, idx);
+        System.arraycopy(bytes, idx + 1, res, idx, (bytes.length - idx - 1));
+        return res;
+    }
+
+    private static void decodeNumericSegment(BitSource bits,
+                                             StringBuilder result,
+                                             int count, List<byte[]> byteSegments) throws FormatException {
+        byte[] byteSegment = new byte[count];
+        int byteCounter = 0;
+        // Read three digits at a time
+        while (count >= 3) {
+            // Each 10 bits encodes three digits
+            if (bits.available() < 10) {
+                throw FormatException.getFormatInstance();
+            }
+            int threeDigitsBits = bits.readBits(10);
+            if (threeDigitsBits >= 1000) {
+                throw FormatException.getFormatInstance();
+            }
+            byteSegment[byteCounter++] = (byte)toAlphaNumericChar(threeDigitsBits / 100);
+            byteSegment[byteCounter++] = (byte)toAlphaNumericChar((threeDigitsBits / 10) % 10);
+            byteSegment[byteCounter++] = (byte)toAlphaNumericChar(threeDigitsBits % 10);
+
+            result.append(toAlphaNumericChar(threeDigitsBits / 100));
+            result.append(toAlphaNumericChar((threeDigitsBits / 10) % 10));
+            result.append(toAlphaNumericChar(threeDigitsBits % 10));
+            count -= 3;
+        }
+        if (count == 2) {
+            // Two digits left over to read, encoded in 7 bits
+            if (bits.available() < 7) {
+                throw FormatException.getFormatInstance();
+            }
+            int twoDigitsBits = bits.readBits(7);
+            if (twoDigitsBits >= 100) {
+                throw FormatException.getFormatInstance();
+            }
+            byteSegment[byteCounter++] = (byte)toAlphaNumericChar(twoDigitsBits / 10);
+            byteSegment[byteCounter++] = (byte)toAlphaNumericChar(twoDigitsBits % 10);
+
+            result.append(toAlphaNumericChar(twoDigitsBits / 10));
+            result.append(toAlphaNumericChar(twoDigitsBits % 10));
+        } else if (count == 1) {
+            // One digit left over to read
+            if (bits.available() < 4) {
+                throw FormatException.getFormatInstance();
+            }
+            int digitBits = bits.readBits(4);
+            if (digitBits >= 10) {
+                throw FormatException.getFormatInstance();
+            }
+            byteSegment[byteCounter++] = (byte)toAlphaNumericChar(digitBits);
+            result.append(toAlphaNumericChar(digitBits));
+        }
+        byteSegments.add(byteSegment);
+    }
+
+    private static int parseECIValue(BitSource bits) throws FormatException {
+        int firstByte = bits.readBits(8);
+        if ((firstByte & 0x80) == 0) {
+            // just one byte
+            return firstByte & 0x7F;
+        }
+        if ((firstByte & 0xC0) == 0x80) {
+            // two bytes
+            int secondByte = bits.readBits(8);
+            return ((firstByte & 0x3F) << 8) | secondByte;
+        }
+        if ((firstByte & 0xE0) == 0xC0) {
+            // three bytes
+            int secondThirdBytes = bits.readBits(16);
+            return ((firstByte & 0x1F) << 16) | secondThirdBytes;
+        }
+        throw FormatException.getFormatInstance();
+    }
+
+}


### PR DESCRIPTION
Issue #481.

Description:
This PR will try to solve the issue with an incorrect reading of QR Codes. It did not read the QRCode correctly because the QRCode could be encoded in multiple different ways to compress as well as possible.

* Numeric
* Alpha Numeric
* Byte stream
* Kanji
* Hanzi

As a URL seldom has Kanji or Hanzi data, I've not addressed these because I don't really understand the encoding.

For byte streams, it's pretty straightforward. They read them and add them to a list. They also add that data to a string value. Numeric or alphanumeric encoding was only added to the string value.

Changes:
My solution adds the byte stream list to the numeric and alphanumeric functions and handles the reading of these encoded values adding them to a byte stream of its own. This will, in turn, give us the expected output when we merge these streams in the application.

This might be a bug I want to report to the ZXing team, and depending on their response, we might remove this code in the future.


QRCodeDecodedBitStreamParser.java is a copy of https://github.com/zxing/zxing/blob/b1c85db64e0ef13e7d8a4c9de32bd94c76eea5d8/core/src/main/java/com/google/zxing/qrcode/decoder/DecodedBitStreamParser.java with some minor changes.

Best regards
Daniel