### PR TITLE
Phase 5: Replace deprecated AsyncTask with ExecutorService + Handler

### DIFF
--- a/app/src/main/java/org/ea/sqrl/utils/PasswordStrengthMeter.java
+++ b/app/src/main/java/org/ea/sqrl/utils/PasswordStrengthMeter.java
@@ -2,7 +2,8 @@ package org.ea.sqrl.utils;
 
 import android.content.Context;
 import android.graphics.drawable.Drawable;
-import android.os.AsyncTask;
+import android.os.Handler;
+import android.os.Looper;
 import androidx.core.content.ContextCompat;
 import android.text.Editable;
 import android.text.TextWatcher;
@@ -15,6 +16,10 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import org.ea.sqrl.R;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Calculates and displays a password strength rating.
@@ -29,7 +34,9 @@ public class PasswordStrengthMeter {
     private final int STRENGTH_POINTS_MIN_GOOD = 17;
     private final Context mContext;
     private ViewGroup mPassStrengthLayout;
-    private CalcPasswordStrengthAsyncTask mLastCalcTask;
+    private final ExecutorService mExecutor = Executors.newSingleThreadExecutor();
+    private final Handler mMainHandler = new Handler(Looper.getMainLooper());
+    private final AtomicInteger mTaskGeneration = new AtomicInteger(0);
 
 
     /**
@@ -57,9 +64,8 @@ public class PasswordStrengthMeter {
             public void afterTextChanged(Editable s) {
                 String password = s.toString();
 
-                if (mLastCalcTask != null) mLastCalcTask.cancel(true);
-                mLastCalcTask = new CalcPasswordStrengthAsyncTask();
-                mLastCalcTask.execute(password);
+                int generation = mTaskGeneration.incrementAndGet();
+                mExecutor.execute(() -> calcPasswordStrength(password, generation));
             }
 
             public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
@@ -67,117 +73,112 @@ public class PasswordStrengthMeter {
         });
     }
 
+    private boolean isCancelled(int generation) {
+        return generation != mTaskGeneration.get();
+    }
 
-    class CalcPasswordStrengthAsyncTask extends AsyncTask<String, Void, PasswordStrengthResult> {
+    private void calcPasswordStrength(String password, int generation) {
 
-        @Override
-        protected PasswordStrengthResult doInBackground(String... args) {
-
-            // This will avoid updating the UI too often on quick password input
-            for (int i=0; i<10; i++) {
-                try { Thread.sleep(5); } catch(Exception e) {}
-                if (isCancelled()) return null;
-            }
-
-            PasswordStrengthResult result = new PasswordStrengthResult();
-            String password = args[0];
-
-            result.passwordLength = password.length();
-            if (result.passwordLength > PW_MIN_LENGTH) {
-                result.strengthPoints = result.passwordLength;
-            } else {
-                result.strengthPoints = (int)(result.passwordLength/2);
-            }
-
-            for (int i = 0; i < password.length(); i++) {
-
-                char c = password.charAt(i);
-
-                if (c >= 65 && c <= 90) {       // Uppercase
-                    if (!result.uppercaseUsed) {
-                        result.strengthPoints += 2;
-                        result.uppercaseUsed = true;
-                    }
-                } else if (c >= 97 && c <= 122) { // Lowercase
-                    if (!result.lowercaseUsed) {
-                        result.lowercaseUsed = true;
-                    }
-                } else if (c >= 48 && c <= 57) {  // Digit
-                    if (!result.digitsUsed) {
-                        result.strengthPoints += 2;
-                        result.digitsUsed = true;
-                    }
-                } else {                          // Symbol
-                    if (!result.symbolsUsed) {
-                        result.strengthPoints += 2;
-                        result.symbolsUsed = true;
-                    }
-                }
-
-                if (result.allCharClassesUsed()) break; // No need to look any further
-                if (isCancelled()) return null;
-            }
-
-            if (result.strengthPoints < STRENGTH_POINTS_MIN_MEDIUM) {
-                result.rating = PasswordRating.POOR;
-            } else if (result.strengthPoints < STRENGTH_POINTS_MIN_GOOD) {
-                result.rating = PasswordRating.MEDIUM;
-            } else result.rating = PasswordRating.GOOD;
-
-            // Last chance to detect cancellation
-            if (isCancelled()) return null;
-
-            return result;
+        // This will avoid updating the UI too often on quick password input
+        for (int i=0; i<10; i++) {
+            try { Thread.sleep(5); } catch(Exception e) {}
+            if (isCancelled(generation)) return;
         }
 
-        @Override
-        protected void onPostExecute(PasswordStrengthResult result) {
+        PasswordStrengthResult result = new PasswordStrengthResult();
 
-            if (result == null) return;
+        result.passwordLength = password.length();
+        if (result.passwordLength > PW_MIN_LENGTH) {
+            result.strengthPoints = result.passwordLength;
+        } else {
+            result.strengthPoints = (int)(result.passwordLength/2);
+        }
 
-            try {
-                Drawable ledGreen = ContextCompat.getDrawable(mContext, R.drawable.led_green);
-                Drawable ledRed   = ContextCompat.getDrawable(mContext, R.drawable.led_red);
-                TextView txtPasswordStrength = mPassStrengthLayout.findViewById(R.id.txtPasswordStrength);
-                TextView txtPasswordWarning = mPassStrengthLayout.findViewById(R.id.txtPasswordWarning);
-                ImageView imgUppercase = mPassStrengthLayout.findViewById(R.id.imgPasswordContainsUppercase);
-                ImageView imgLowercase = mPassStrengthLayout.findViewById(R.id.imgPasswordContainsLowercase);
-                ImageView imgDigits = mPassStrengthLayout.findViewById(R.id.imgPasswordContainsDigits);
-                ImageView imgSymbols = mPassStrengthLayout.findViewById(R.id.imgSymbols);
-                ProgressBar progressPwStrength = mPassStrengthLayout.findViewById(R.id.progressPasswordStrength);
+        for (int i = 0; i < password.length(); i++) {
 
-                progressPwStrength.setMax(STRENGTH_POINTS_MIN_GOOD);
-                progressPwStrength.setProgress(result.strengthPoints);
+            char c = password.charAt(i);
 
-                if (result.rating == PasswordRating.POOR) {
-                    txtPasswordStrength.setText(mContext.getText(R.string.password_strength_poor));
-                    txtPasswordStrength.setBackgroundColor(
-                            ContextCompat.getColor(mContext, R.color.password_strength_poor));
-                } else if (result.rating == PasswordRating.MEDIUM) {
-                    txtPasswordStrength.setText(mContext.getText(R.string.password_strength_medium));
-                    txtPasswordStrength.setBackgroundColor(
-                            ContextCompat.getColor(mContext, R.color.password_strength_medium));
-                } else if (result.rating == PasswordRating.GOOD) {
-                    txtPasswordStrength.setText(mContext.getText(R.string.password_strength_good));
-                    txtPasswordStrength.setBackgroundColor(
-                            ContextCompat.getColor(mContext, R.color.password_strength_good));
+            if (c >= 65 && c <= 90) {       // Uppercase
+                if (!result.uppercaseUsed) {
+                    result.strengthPoints += 2;
+                    result.uppercaseUsed = true;
                 }
-
-                imgLowercase.setImageDrawable(result.lowercaseUsed ? ledGreen : ledRed);
-                imgUppercase.setImageDrawable(result.uppercaseUsed ? ledGreen : ledRed);
-                imgDigits.setImageDrawable(result.digitsUsed ? ledGreen : ledRed);
-                imgSymbols.setImageDrawable(result.symbolsUsed ? ledGreen : ledRed);
-
-                if (result.passwordLength > 0 && result.passwordLength < PW_MIN_LENGTH) {
-                    txtPasswordWarning.setText(R.string.short_password_warning);
-                    txtPasswordWarning.setVisibility(View.VISIBLE);
-                } else {
-                    txtPasswordWarning.setVisibility(View.GONE);
+            } else if (c >= 97 && c <= 122) { // Lowercase
+                if (!result.lowercaseUsed) {
+                    result.lowercaseUsed = true;
+                }
+            } else if (c >= 48 && c <= 57) {  // Digit
+                if (!result.digitsUsed) {
+                    result.strengthPoints += 2;
+                    result.digitsUsed = true;
+                }
+            } else {                          // Symbol
+                if (!result.symbolsUsed) {
+                    result.strengthPoints += 2;
+                    result.symbolsUsed = true;
                 }
             }
-            catch (Exception e) {
-                e.printStackTrace();
+
+            if (result.allCharClassesUsed()) break; // No need to look any further
+            if (isCancelled(generation)) return;
+        }
+
+        if (result.strengthPoints < STRENGTH_POINTS_MIN_MEDIUM) {
+            result.rating = PasswordRating.POOR;
+        } else if (result.strengthPoints < STRENGTH_POINTS_MIN_GOOD) {
+            result.rating = PasswordRating.MEDIUM;
+        } else result.rating = PasswordRating.GOOD;
+
+        // Last chance to detect cancellation
+        if (isCancelled(generation)) return;
+
+        mMainHandler.post(() -> updateStrengthUI(result));
+    }
+
+    private void updateStrengthUI(PasswordStrengthResult result) {
+
+        try {
+            Drawable ledGreen = ContextCompat.getDrawable(mContext, R.drawable.led_green);
+            Drawable ledRed   = ContextCompat.getDrawable(mContext, R.drawable.led_red);
+            TextView txtPasswordStrength = mPassStrengthLayout.findViewById(R.id.txtPasswordStrength);
+            TextView txtPasswordWarning = mPassStrengthLayout.findViewById(R.id.txtPasswordWarning);
+            ImageView imgUppercase = mPassStrengthLayout.findViewById(R.id.imgPasswordContainsUppercase);
+            ImageView imgLowercase = mPassStrengthLayout.findViewById(R.id.imgPasswordContainsLowercase);
+            ImageView imgDigits = mPassStrengthLayout.findViewById(R.id.imgPasswordContainsDigits);
+            ImageView imgSymbols = mPassStrengthLayout.findViewById(R.id.imgSymbols);
+            ProgressBar progressPwStrength = mPassStrengthLayout.findViewById(R.id.progressPasswordStrength);
+
+            progressPwStrength.setMax(STRENGTH_POINTS_MIN_GOOD);
+            progressPwStrength.setProgress(result.strengthPoints);
+
+            if (result.rating == PasswordRating.POOR) {
+                txtPasswordStrength.setText(mContext.getText(R.string.password_strength_poor));
+                txtPasswordStrength.setBackgroundColor(
+                        ContextCompat.getColor(mContext, R.color.password_strength_poor));
+            } else if (result.rating == PasswordRating.MEDIUM) {
+                txtPasswordStrength.setText(mContext.getText(R.string.password_strength_medium));
+                txtPasswordStrength.setBackgroundColor(
+                        ContextCompat.getColor(mContext, R.color.password_strength_medium));
+            } else if (result.rating == PasswordRating.GOOD) {
+                txtPasswordStrength.setText(mContext.getText(R.string.password_strength_good));
+                txtPasswordStrength.setBackgroundColor(
+                        ContextCompat.getColor(mContext, R.color.password_strength_good));
             }
+
+            imgLowercase.setImageDrawable(result.lowercaseUsed ? ledGreen : ledRed);
+            imgUppercase.setImageDrawable(result.uppercaseUsed ? ledGreen : ledRed);
+            imgDigits.setImageDrawable(result.digitsUsed ? ledGreen : ledRed);
+            imgSymbols.setImageDrawable(result.symbolsUsed ? ledGreen : ledRed);
+
+            if (result.passwordLength > 0 && result.passwordLength < PW_MIN_LENGTH) {
+                txtPasswordWarning.setText(R.string.short_password_warning);
+                txtPasswordWarning.setVisibility(View.VISIBLE);
+            } else {
+                txtPasswordWarning.setVisibility(View.GONE);
+            }
+        }
+        catch (Exception e) {
+            e.printStackTrace();
         }
     }
 


### PR DESCRIPTION
AsyncTask was deprecated in API 30 and has unreliable thread pool behavior on newer Android versions. Replace with ExecutorService + Handler pattern in PasswordStrengthMeter, the only file using AsyncTask. Uses AtomicInteger generation counter for cancellation, preserving identical debounce and strength calculation behavior.

Issue #.
*Add the issue if any that this pull request referes to.*

Description:
*Short summerizing description of the changes*

Changes:
*Add what changes this pull request include*
