### PR TITLE
Phase 6: Add release signing config and bump version to 1.7.3

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,10 +7,38 @@ android {
         applicationId "org.ea.sqrl"
         minSdk 21
         targetSdk 34
-        versionCode 54
-        versionName "1.7.2"
+        versionCode 55
+        versionName "1.7.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
+    }
+
+    // Release signing credentials — set these in ~/.gradle/gradle.properties or as
+    // environment variables. NEVER hardcode keystore paths or passwords in this file.
+    //
+    //   SQRL_STORE_FILE=/path/to/keystore.jks
+    //   SQRL_STORE_PASSWORD=****
+    //   SQRL_KEY_ALIAS=****
+    //   SQRL_KEY_PASSWORD=****
+    if (findProperty('SQRL_STORE_FILE') != null &&
+        findProperty('SQRL_STORE_PASSWORD') != null &&
+        findProperty('SQRL_KEY_ALIAS') != null &&
+        findProperty('SQRL_KEY_PASSWORD') != null) {
+        signingConfigs {
+            release {
+                storeFile file(SQRL_STORE_FILE)
+                storePassword SQRL_STORE_PASSWORD
+                keyAlias SQRL_KEY_ALIAS
+                keyPassword SQRL_KEY_PASSWORD
+            }
+        }
+        buildTypes {
+            release {
+                minifyEnabled true
+                proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+                signingConfig signingConfigs.release
+            }
+        }
     }
 
     buildFeatures {


### PR DESCRIPTION
Prepare for Play Store republication by adding a conditional signingConfigs.release block that reads keystore credentials from Gradle properties or environment variables (never hardcoded), and bumping versionCode to 55 / versionName to "1.7.3".

Issue #.
*Add the issue if any that this pull request referes to.*

Description:
*Short summerizing description of the changes*

Changes:
*Add what changes this pull request include*
